### PR TITLE
Add @EnableR2dbcRepositories configuration infrastructure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<version>1.0.0.gh-13-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC.</description>

--- a/src/main/java/org/springframework/data/r2dbc/InvalidResultAccessException.java
+++ b/src/main/java/org/springframework/data/r2dbc/InvalidResultAccessException.java
@@ -25,7 +25,7 @@ import org.springframework.lang.Nullable;
  * Exception thrown when a {@link io.r2dbc.spi.Result} has been accessed in an invalid fashion. Such exceptions always
  * have a {@link io.r2dbc.spi.R2dbcException} root cause.
  * <p>
- * This typically happens when an invalid {@link Result} column index or name has been specified.
+ * This typically happens when an invalid {@link org.springframework.data.r2dbc.function.SqlResult} column index or name has been specified.
  *
  * @author Mark Paluch
  * @see BadSqlGrammarException
@@ -42,7 +42,7 @@ public class InvalidResultAccessException extends InvalidDataAccessResourceUsage
 	 * @param sql the offending SQL statement.
 	 * @param ex the root cause.
 	 */
-	public InvalidResultAccessException(String task, String sql, R2dbcException ex) {
+	public InvalidResultAccessException(String task, @Nullable String sql, R2dbcException ex) {
 
 		super(task + "; invalid Result access for SQL [" + sql + "]", ex);
 

--- a/src/main/java/org/springframework/data/r2dbc/function/connectionfactory/package-info.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/connectionfactory/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Connection and ConnectionFactory specifics for R2DBC.
+ */
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package org.springframework.data.r2dbc.function.connectionfactory;

--- a/src/main/java/org/springframework/data/r2dbc/function/convert/EntityRowMapper.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/convert/EntityRowMapper.java
@@ -33,6 +33,7 @@ import org.springframework.data.mapping.model.ParameterValueProvider;
 import org.springframework.data.relational.core.conversion.RelationalConverter;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
+import org.springframework.lang.Nullable;
 
 /**
  * Maps a {@link io.r2dbc.spi.Row} to an entity of type {@code T}, including entities referenced.
@@ -150,6 +151,7 @@ public class EntityRowMapper<T> implements BiFunction<Row, RowMetadata, T> {
 		 * @see org.springframework.data.mapping.model.ParameterValueProvider#getParameterValue(org.springframework.data.mapping.PreferredConstructor.Parameter)
 		 */
 		@Override
+		@Nullable
 		public <T> T getParameterValue(Parameter<T, RelationalPersistentProperty> parameter) {
 
 			String column = prefix + entity.getRequiredPersistentProperty(parameter.getName()).getColumnName();

--- a/src/main/java/org/springframework/data/r2dbc/function/convert/package-info.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/convert/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * R2DBC-specific conversion and converter implementations.
+ */
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package org.springframework.data.r2dbc.function.convert;

--- a/src/main/java/org/springframework/data/r2dbc/function/package-info.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Core domain types around DatabaseClient.
+ */
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package org.springframework.data.r2dbc.function;

--- a/src/main/java/org/springframework/data/r2dbc/package-info.java
+++ b/src/main/java/org/springframework/data/r2dbc/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Support infrastructure for the configuration of R2DBC-specific repositories.
+ */
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package org.springframework.data.r2dbc;

--- a/src/main/java/org/springframework/data/r2dbc/repository/config/AbstractR2dbcConfiguration.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/config/AbstractR2dbcConfiguration.java
@@ -1,9 +1,23 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.data.r2dbc.repository.config;
-
-import io.r2dbc.spi.ConnectionFactory;
 
 import java.util.Optional;
 
+import io.r2dbc.spi.ConnectionFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.r2dbc.function.DatabaseClient;
@@ -14,6 +28,7 @@ import org.springframework.data.r2dbc.support.SqlErrorCodeR2dbcExceptionTranslat
 import org.springframework.data.relational.core.conversion.BasicRelationalConverter;
 import org.springframework.data.relational.core.mapping.NamingStrategy;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
+import org.springframework.util.Assert;
 
 /**
  * Base class for Spring Data R2DBC configuration containing bean declarations that must be registered for Spring Data
@@ -39,13 +54,20 @@ public abstract class AbstractR2dbcConfiguration {
 	 * Register a {@link DatabaseClient} using {@link #connectionFactory()} and {@link RelationalMappingContext}.
 	 *
 	 * @return must not be {@literal null}.
+	 * @throws IllegalArgumentException if any of the required args is {@literal null}.
 	 */
 	@Bean
 	public DatabaseClient databaseClient(ReactiveDataAccessStrategy dataAccessStrategy,
 			R2dbcExceptionTranslator exceptionTranslator) {
 
-		return DatabaseClient.builder().connectionFactory(connectionFactory()).dataAccessStrategy(dataAccessStrategy)
-				.exceptionTranslator(exceptionTranslator).build();
+		Assert.notNull(dataAccessStrategy, "DataAccessStrategy must not be null!");
+		Assert.notNull(exceptionTranslator, "ExceptionTranslator must not be null!");
+
+		return DatabaseClient.builder() //
+				.connectionFactory(connectionFactory()) //
+				.dataAccessStrategy(dataAccessStrategy) //
+				.exceptionTranslator(exceptionTranslator) //
+				.build();
 	}
 
 	/**
@@ -53,26 +75,33 @@ public abstract class AbstractR2dbcConfiguration {
 	 *
 	 * @param namingStrategy optional {@link NamingStrategy}. Use {@link NamingStrategy#INSTANCE} as fallback.
 	 * @return must not be {@literal null}.
+	 * @throws IllegalArgumentException if any of the required args is {@literal null}.
 	 */
 	@Bean
 	public RelationalMappingContext r2dbcMappingContext(Optional<NamingStrategy> namingStrategy) {
+
+		Assert.notNull(namingStrategy, "NamingStrategy must not be null!");
+
 		return new RelationalMappingContext(namingStrategy.orElse(NamingStrategy.INSTANCE));
 	}
 
 	/**
-	 * Creates a {@link ReactiveDataAccessStrategy} using the configured {@link #r2dbcMappingContext(Optional)}.
+	 * Creates a {@link ReactiveDataAccessStrategy} using the configured {@link #r2dbcMappingContext(Optional) RelationalMappingContext}.
 	 *
 	 * @param mappingContext the configured {@link RelationalMappingContext}.
 	 * @return must not be {@literal null}.
 	 * @see #r2dbcMappingContext(Optional)
+	 * @throws IllegalArgumentException if any of the {@literal mappingContext} is {@literal null}.
 	 */
 	@Bean
 	public ReactiveDataAccessStrategy reactiveDataAccessStrategy(RelationalMappingContext mappingContext) {
+
+		Assert.notNull(mappingContext, "MappingContext must not be null!");
 		return new DefaultReactiveDataAccessStrategy(new BasicRelationalConverter(mappingContext));
 	}
 
 	/**
-	 * Creates a {@link R2dbcExceptionTranslator} using the configured {@link #connectionFactory()}.
+	 * Creates a {@link R2dbcExceptionTranslator} using the configured {@link #connectionFactory() ConnectionFactory}.
 	 *
 	 * @return must not be {@literal null}.
 	 * @see #connectionFactory()

--- a/src/main/java/org/springframework/data/r2dbc/repository/config/AbstractR2dbcConfiguration.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/config/AbstractR2dbcConfiguration.java
@@ -1,0 +1,84 @@
+package org.springframework.data.r2dbc.repository.config;
+
+import io.r2dbc.spi.ConnectionFactory;
+
+import java.util.Optional;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.r2dbc.function.DatabaseClient;
+import org.springframework.data.r2dbc.function.DefaultReactiveDataAccessStrategy;
+import org.springframework.data.r2dbc.function.ReactiveDataAccessStrategy;
+import org.springframework.data.r2dbc.support.R2dbcExceptionTranslator;
+import org.springframework.data.r2dbc.support.SqlErrorCodeR2dbcExceptionTranslator;
+import org.springframework.data.relational.core.conversion.BasicRelationalConverter;
+import org.springframework.data.relational.core.mapping.NamingStrategy;
+import org.springframework.data.relational.core.mapping.RelationalMappingContext;
+
+/**
+ * Base class for Spring Data R2DBC configuration containing bean declarations that must be registered for Spring Data
+ * R2DBC to work.
+ *
+ * @author Mark Paluch
+ * @see ConnectionFactory
+ * @see DatabaseClient
+ * @see EnableR2dbcRepositories
+ */
+@Configuration
+public abstract class AbstractR2dbcConfiguration {
+
+	/**
+	 * Return a R2DBC {@link ConnectionFactory}. Annotate with {@link Bean} in case you want to expose a
+	 * {@link ConnectionFactory} instance to the {@link org.springframework.context.ApplicationContext}.
+	 *
+	 * @return the configured {@link ConnectionFactory}.
+	 */
+	public abstract ConnectionFactory connectionFactory();
+
+	/**
+	 * Register a {@link DatabaseClient} using {@link #connectionFactory()} and {@link RelationalMappingContext}.
+	 *
+	 * @return must not be {@literal null}.
+	 */
+	@Bean
+	public DatabaseClient databaseClient(ReactiveDataAccessStrategy dataAccessStrategy,
+			R2dbcExceptionTranslator exceptionTranslator) {
+
+		return DatabaseClient.builder().connectionFactory(connectionFactory()).dataAccessStrategy(dataAccessStrategy)
+				.exceptionTranslator(exceptionTranslator).build();
+	}
+
+	/**
+	 * Register a {@link RelationalMappingContext} and apply an optional {@link NamingStrategy}.
+	 *
+	 * @param namingStrategy optional {@link NamingStrategy}. Use {@link NamingStrategy#INSTANCE} as fallback.
+	 * @return must not be {@literal null}.
+	 */
+	@Bean
+	public RelationalMappingContext r2dbcMappingContext(Optional<NamingStrategy> namingStrategy) {
+		return new RelationalMappingContext(namingStrategy.orElse(NamingStrategy.INSTANCE));
+	}
+
+	/**
+	 * Creates a {@link ReactiveDataAccessStrategy} using the configured {@link #r2dbcMappingContext(Optional)}.
+	 *
+	 * @param mappingContext the configured {@link RelationalMappingContext}.
+	 * @return must not be {@literal null}.
+	 * @see #r2dbcMappingContext(Optional)
+	 */
+	@Bean
+	public ReactiveDataAccessStrategy reactiveDataAccessStrategy(RelationalMappingContext mappingContext) {
+		return new DefaultReactiveDataAccessStrategy(new BasicRelationalConverter(mappingContext));
+	}
+
+	/**
+	 * Creates a {@link R2dbcExceptionTranslator} using the configured {@link #connectionFactory()}.
+	 *
+	 * @return must not be {@literal null}.
+	 * @see #connectionFactory()
+	 */
+	@Bean
+	public R2dbcExceptionTranslator exceptionTranslator() {
+		return new SqlErrorCodeR2dbcExceptionTranslator(connectionFactory());
+	}
+}

--- a/src/main/java/org/springframework/data/r2dbc/repository/config/EnableR2dbcRepositories.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/config/EnableR2dbcRepositories.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.r2dbc.repository.config;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.r2dbc.repository.support.R2dbcRepositoryFactoryBean;
+import org.springframework.data.repository.config.DefaultRepositoryBaseClass;
+import org.springframework.data.repository.query.QueryLookupStrategy;
+import org.springframework.data.repository.query.QueryLookupStrategy.Key;
+
+/**
+ * Annotation to activate reactive relational repositories using R2DBC. If no base package is configured through either
+ * {@link #value()}, {@link #basePackages()} or {@link #basePackageClasses()} it will trigger scanning of the package of
+ * annotated class.
+ *
+ * @author Mark Paluch
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@Import(R2dbcRepositoriesRegistrar.class)
+public @interface EnableR2dbcRepositories {
+
+	/**
+	 * Alias for the {@link #basePackages()} attribute. Allows for more concise annotation declarations e.g.:
+	 * {@code @EnableReactiveRelationalRepositories("org.my.pkg")} instead of
+	 * {@code @EnableReactiveRelationalRepositories(basePackages="org.my.pkg")}.
+	 */
+	String[] value() default {};
+
+	/**
+	 * Base packages to scan for annotated components. {@link #value()} is an alias for (and mutually exclusive with) this
+	 * attribute. Use {@link #basePackageClasses()} for a type-safe alternative to String-based package names.
+	 */
+	String[] basePackages() default {};
+
+	/**
+	 * Type-safe alternative to {@link #basePackages()} for specifying the packages to scan for annotated components. The
+	 * package of each class specified will be scanned. Consider creating a special no-op marker class or interface in
+	 * each package that serves no purpose other than being referenced by this attribute.
+	 */
+	Class<?>[] basePackageClasses() default {};
+
+	/**
+	 * Specifies which types are eligible for component scanning. Further narrows the set of candidate components from
+	 * everything in {@link #basePackages()} to everything in the base packages that matches the given filter or filters.
+	 */
+	Filter[] includeFilters() default {};
+
+	/**
+	 * Specifies which types are not eligible for component scanning.
+	 */
+	Filter[] excludeFilters() default {};
+
+	/**
+	 * Returns the postfix to be used when looking up custom repository implementations. Defaults to {@literal Impl}. So
+	 * for a repository named {@code PersonRepository} the corresponding implementation class will be looked up scanning
+	 * for {@code PersonRepositoryImpl}.
+	 *
+	 * @return
+	 */
+	String repositoryImplementationPostfix() default "Impl";
+
+	/**
+	 * Configures the location of where to find the Spring Data named queries properties file. Will default to
+	 * {@code META-INF/r2dbc-named-queries.properties}.
+	 *
+	 * @return
+	 */
+	String namedQueriesLocation() default "";
+
+	/**
+	 * Returns the key of the {@link QueryLookupStrategy} to be used for lookup queries for query methods. Defaults to
+	 * {@link Key#CREATE_IF_NOT_FOUND}.
+	 *
+	 * @return
+	 */
+	Key queryLookupStrategy() default Key.CREATE_IF_NOT_FOUND;
+
+	/**
+	 * Returns the {@link FactoryBean} class to be used for each repository instance. Defaults to
+	 * {@link R2dbcRepositoryFactoryBean}.
+	 *
+	 * @return
+	 */
+	Class<?> repositoryFactoryBeanClass() default R2dbcRepositoryFactoryBean.class;
+
+	/**
+	 * Configure the repository base class to be used to create repository proxies for this particular configuration.
+	 *
+	 * @return
+	 */
+	Class<?> repositoryBaseClass() default DefaultRepositoryBaseClass.class;
+
+	/**
+	 * Configures the name of the {@link org.springframework.data.r2dbc.function.DatabaseClient} bean to be used with the
+	 * repositories detected.
+	 *
+	 * @return
+	 */
+	String databaseClientRef() default "databaseClient";
+
+	/**
+	 * Configures whether nested repository-interfaces (e.g. defined as inner classes) should be discovered by the
+	 * repositories infrastructure.
+	 */
+	boolean considerNestedRepositories() default false;
+}

--- a/src/main/java/org/springframework/data/r2dbc/repository/config/EnableR2dbcRepositories.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/config/EnableR2dbcRepositories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.r2dbc.repository.config;
 
 import java.lang.annotation.Documented;
@@ -37,6 +36,7 @@ import org.springframework.data.repository.query.QueryLookupStrategy.Key;
  * annotated class.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
@@ -87,7 +87,7 @@ public @interface EnableR2dbcRepositories {
 
 	/**
 	 * Configures the location of where to find the Spring Data named queries properties file. Will default to
-	 * {@code META-INF/r2dbc-named-queries.properties}.
+	 * {@code META-INF/r2dbc-named-queries.properties} if not configured otherwise.
 	 *
 	 * @return
 	 */

--- a/src/main/java/org/springframework/data/r2dbc/repository/config/R2dbcRepositoriesRegistrar.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/config/R2dbcRepositoriesRegistrar.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.data.r2dbc.repository.config;
 
 import java.lang.annotation.Annotation;

--- a/src/main/java/org/springframework/data/r2dbc/repository/config/R2dbcRepositoriesRegistrar.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/config/R2dbcRepositoriesRegistrar.java
@@ -1,0 +1,33 @@
+package org.springframework.data.r2dbc.repository.config;
+
+import java.lang.annotation.Annotation;
+
+import org.springframework.data.repository.config.RepositoryBeanDefinitionRegistrarSupport;
+import org.springframework.data.repository.config.RepositoryConfigurationExtension;
+
+/**
+ * R2DBC-specific {@link org.springframework.context.annotation.ImportBeanDefinitionRegistrar}.
+ *
+ * @author Mark Paluch
+ * @since 2.0
+ */
+class R2dbcRepositoriesRegistrar extends RepositoryBeanDefinitionRegistrarSupport {
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.config.RepositoryBeanDefinitionRegistrarSupport#getAnnotation()
+	 */
+	@Override
+	protected Class<? extends Annotation> getAnnotation() {
+		return EnableR2dbcRepositories.class;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.config.RepositoryBeanDefinitionRegistrarSupport#getExtension()
+	 */
+	@Override
+	protected RepositoryConfigurationExtension getExtension() {
+		return new R2dbcRepositoryConfigurationExtension();
+	}
+}

--- a/src/main/java/org/springframework/data/r2dbc/repository/config/R2dbcRepositoryConfigurationExtension.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/config/R2dbcRepositoryConfigurationExtension.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.repository.config;
+
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+import java.util.Collections;
+
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.core.annotation.AnnotationAttributes;
+import org.springframework.data.r2dbc.repository.R2dbcRepository;
+import org.springframework.data.r2dbc.repository.support.R2dbcRepositoryFactoryBean;
+import org.springframework.data.relational.core.mapping.Table;
+import org.springframework.data.repository.config.AnnotationRepositoryConfigurationSource;
+import org.springframework.data.repository.config.RepositoryConfigurationExtension;
+import org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport;
+import org.springframework.data.repository.config.XmlRepositoryConfigurationSource;
+import org.springframework.data.repository.core.RepositoryMetadata;
+
+/**
+ * Reactive {@link RepositoryConfigurationExtension} for R2DBC.
+ *
+ * @author Mark Paluch
+ */
+public class R2dbcRepositoryConfigurationExtension extends RepositoryConfigurationExtensionSupport {
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport#getModuleName()
+	 */
+	@Override
+	public String getModuleName() {
+		return "R2DBC";
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport#getModulePrefix()
+	 */
+	@Override
+	protected String getModulePrefix() {
+		return "r2dbc";
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.config.RepositoryConfigurationExtension#getRepositoryFactoryBeanClassName()
+	 */
+	public String getRepositoryFactoryBeanClassName() {
+		return R2dbcRepositoryFactoryBean.class.getName();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport#getIdentifyingAnnotations()
+	 */
+	@Override
+	protected Collection<Class<? extends Annotation>> getIdentifyingAnnotations() {
+		return Collections.singleton(Table.class);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport#getIdentifyingTypes()
+	 */
+	@Override
+	protected Collection<Class<?>> getIdentifyingTypes() {
+		return Collections.singleton(R2dbcRepository.class);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport#postProcess(org.springframework.beans.factory.support.BeanDefinitionBuilder, org.springframework.data.repository.config.XmlRepositoryConfigurationSource)
+	 */
+	@Override
+	public void postProcess(BeanDefinitionBuilder builder, XmlRepositoryConfigurationSource config) {}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport#postProcess(org.springframework.beans.factory.support.BeanDefinitionBuilder, org.springframework.data.repository.config.AnnotationRepositoryConfigurationSource)
+	 */
+	@Override
+	public void postProcess(BeanDefinitionBuilder builder, AnnotationRepositoryConfigurationSource config) {
+
+		AnnotationAttributes attributes = config.getAttributes();
+
+		builder.addPropertyReference("databaseClient", attributes.getString("databaseClientRef"));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport#useRepositoryConfiguration(org.springframework.data.repository.core.RepositoryMetadata)
+	 */
+	@Override
+	protected boolean useRepositoryConfiguration(RepositoryMetadata metadata) {
+		return metadata.isReactiveRepository();
+	}
+}

--- a/src/main/java/org/springframework/data/r2dbc/repository/config/R2dbcRepositoryConfigurationExtension.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/config/R2dbcRepositoryConfigurationExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/data/r2dbc/repository/config/package-info.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/config/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Support infrastructure for the configuration of R2DBC-specific repositories.
+ */
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
+package org.springframework.data.r2dbc.repository.config;

--- a/src/main/java/org/springframework/data/r2dbc/repository/package-info.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/package-info.java
@@ -1,7 +1,6 @@
 /**
  * R2DBC-specific repository implementation.
  */
-@NonNullApi
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
 package org.springframework.data.r2dbc.repository;
-
-import org.springframework.lang.NonNullApi;

--- a/src/main/java/org/springframework/data/r2dbc/repository/support/R2dbcRepositoryFactoryBean.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/support/R2dbcRepositoryFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,13 +33,15 @@ import org.springframework.util.Assert;
  * {@link org.springframework.data.r2dbc.repository.R2dbcRepository} instances.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  * @see org.springframework.data.repository.reactive.ReactiveCrudRepository
  */
 public class R2dbcRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extends Serializable>
 		extends RepositoryFactoryBeanSupport<T, S, ID> {
 
 	private @Nullable DatabaseClient client;
-	private @Nullable MappingContext<? extends RelationalPersistentEntity<?>, RelationalPersistentProperty> mappingContext;
+	private @Nullable
+	MappingContext<? extends RelationalPersistentEntity<?>, RelationalPersistentProperty> mappingContext;
 
 	private boolean mappingContextConfigured = false;
 
@@ -67,13 +69,21 @@ public class R2dbcRepositoryFactoryBean<T extends Repository<S, ID>, S, ID exten
 	 */
 	@Override
 	@SuppressWarnings("unchecked")
-	protected void setMappingContext(MappingContext<?, ?> mappingContext) {
+	protected void setMappingContext(@Nullable MappingContext<?, ?> mappingContext) {
 
 		super.setMappingContext(mappingContext);
-		this.mappingContext = (MappingContext<? extends RelationalPersistentEntity<?>, RelationalPersistentProperty>) mappingContext;
-		this.mappingContextConfigured = true;
+
+		if (mappingContext != null) {
+
+			this.mappingContext = (MappingContext<? extends RelationalPersistentEntity<?>, RelationalPersistentProperty>) mappingContext;
+			this.mappingContextConfigured = true;
+		}
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport#createRepositoryFactory()
+	 */
 	@Override
 	protected final RepositoryFactorySupport createRepositoryFactory() {
 		return getFactoryInstance(client, this.mappingContext);
@@ -82,15 +92,19 @@ public class R2dbcRepositoryFactoryBean<T extends Repository<S, ID>, S, ID exten
 	/**
 	 * Creates and initializes a {@link RepositoryFactorySupport} instance.
 	 *
-	 * @param client
-	 * @param mappingContext
-	 * @return
+	 * @param client must not be {@literal null}.
+	 * @param mappingContext must not be {@literal null}.
+	 * @return new instance of {@link RepositoryFactorySupport}.
 	 */
 	protected RepositoryFactorySupport getFactoryInstance(DatabaseClient client,
 			MappingContext<? extends RelationalPersistentEntity<?>, RelationalPersistentProperty> mappingContext) {
 		return new R2dbcRepositoryFactory(client, mappingContext);
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.beans.factory.InitializingBean#afterPropertiesSet()
+	 */
 	@Override
 	public void afterPropertiesSet() {
 

--- a/src/main/java/org/springframework/data/r2dbc/repository/support/R2dbcRepositoryFactoryBean.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/support/R2dbcRepositoryFactoryBean.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.repository.support;
+
+import java.io.Serializable;
+
+import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.r2dbc.function.DatabaseClient;
+import org.springframework.data.relational.core.mapping.RelationalMappingContext;
+import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
+import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
+import org.springframework.data.repository.core.support.RepositoryFactorySupport;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * {@link org.springframework.beans.factory.FactoryBean} to create
+ * {@link org.springframework.data.r2dbc.repository.R2dbcRepository} instances.
+ *
+ * @author Mark Paluch
+ * @see org.springframework.data.repository.reactive.ReactiveCrudRepository
+ */
+public class R2dbcRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extends Serializable>
+		extends RepositoryFactoryBeanSupport<T, S, ID> {
+
+	private @Nullable DatabaseClient client;
+	private @Nullable MappingContext<? extends RelationalPersistentEntity<?>, RelationalPersistentProperty> mappingContext;
+
+	private boolean mappingContextConfigured = false;
+
+	/**
+	 * Creates a new {@link R2dbcRepositoryFactoryBean} for the given repository interface.
+	 *
+	 * @param repositoryInterface must not be {@literal null}.
+	 */
+	public R2dbcRepositoryFactoryBean(Class<? extends T> repositoryInterface) {
+		super(repositoryInterface);
+	}
+
+	/**
+	 * Configures the {@link DatabaseClient} to be used.
+	 *
+	 * @param client the client to set
+	 */
+	public void setDatabaseClient(@Nullable DatabaseClient client) {
+		this.client = client;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport#setMappingContext(org.springframework.data.mapping.context.MappingContext)
+	 */
+	@Override
+	@SuppressWarnings("unchecked")
+	protected void setMappingContext(MappingContext<?, ?> mappingContext) {
+
+		super.setMappingContext(mappingContext);
+		this.mappingContext = (MappingContext<? extends RelationalPersistentEntity<?>, RelationalPersistentProperty>) mappingContext;
+		this.mappingContextConfigured = true;
+	}
+
+	@Override
+	protected final RepositoryFactorySupport createRepositoryFactory() {
+		return getFactoryInstance(client, this.mappingContext);
+	}
+
+	/**
+	 * Creates and initializes a {@link RepositoryFactorySupport} instance.
+	 *
+	 * @param client
+	 * @param mappingContext
+	 * @return
+	 */
+	protected RepositoryFactorySupport getFactoryInstance(DatabaseClient client,
+			MappingContext<? extends RelationalPersistentEntity<?>, RelationalPersistentProperty> mappingContext) {
+		return new R2dbcRepositoryFactory(client, mappingContext);
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+
+		Assert.state(client != null, "DatabaseClient must not be null!");
+
+		if (!mappingContextConfigured) {
+			setMappingContext(new RelationalMappingContext());
+		}
+
+		super.afterPropertiesSet();
+	}
+}

--- a/src/main/java/org/springframework/data/r2dbc/repository/support/package-info.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/support/package-info.java
@@ -1,7 +1,6 @@
 /**
  * Support infrastructure for query derivation of R2DBC-specific repositories.
  */
-@NonNullApi
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
 package org.springframework.data.r2dbc.repository.support;
-
-import org.springframework.lang.NonNullApi;

--- a/src/main/java/org/springframework/data/r2dbc/support/SqlErrorCodeR2dbcExceptionTranslator.java
+++ b/src/main/java/org/springframework/data/r2dbc/support/SqlErrorCodeR2dbcExceptionTranslator.java
@@ -104,7 +104,7 @@ public class SqlErrorCodeR2dbcExceptionTranslator extends AbstractFallbackR2dbcE
 	 *
 	 * @param sec error codes
 	 */
-	public SqlErrorCodeR2dbcExceptionTranslator(SQLErrorCodes sec) {
+	public SqlErrorCodeR2dbcExceptionTranslator(@Nullable SQLErrorCodes sec) {
 		this();
 		this.sqlErrorCodes = sec;
 	}

--- a/src/main/java/org/springframework/data/r2dbc/support/package-info.java
+++ b/src/main/java/org/springframework/data/r2dbc/support/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Support infrastructure for the configuration of R2DBC-specific repositories.
+ */
+@org.springframework.lang.NonNullApi
+package org.springframework.data.r2dbc.support;

--- a/src/test/java/org/springframework/data/r2dbc/repository/config/Person.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/config/Person.java
@@ -1,0 +1,6 @@
+package org.springframework.data.r2dbc.repository.config;
+
+/**
+ * @author Mark Paluch
+ */
+class Person {}

--- a/src/test/java/org/springframework/data/r2dbc/repository/config/Person.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/config/Person.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.data.r2dbc.repository.config;
 
 /**

--- a/src/test/java/org/springframework/data/r2dbc/repository/config/PersonRepository.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/config/PersonRepository.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.data.r2dbc.repository.config;
 
 import org.springframework.data.r2dbc.repository.R2dbcRepository;

--- a/src/test/java/org/springframework/data/r2dbc/repository/config/PersonRepository.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/config/PersonRepository.java
@@ -1,0 +1,8 @@
+package org.springframework.data.r2dbc.repository.config;
+
+import org.springframework.data.r2dbc.repository.R2dbcRepository;
+
+/**
+ * @author Mark Paluch
+ */
+interface PersonRepository extends R2dbcRepository<Person, String> {}

--- a/src/test/java/org/springframework/data/r2dbc/repository/config/R2dbcRepositoriesRegistrarTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/config/R2dbcRepositoriesRegistrarTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.data.r2dbc.repository.config;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.r2dbc.function.DatabaseClient;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * Integration tests for {@link R2dbcRepositoriesRegistrar}.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration
+public class R2dbcRepositoriesRegistrarTests {
+
+	@Configuration
+	@EnableR2dbcRepositories(basePackages = "org.springframework.data.r2dbc.repository.config")
+	static class Config {
+
+		@Bean
+		public DatabaseClient databaseClient() {
+			return mock(DatabaseClient.class);
+		}
+	}
+
+	@Autowired PersonRepository personRepository;
+	@Autowired ApplicationContext context;
+
+	@Test // gh-13
+	public void testConfiguration() {}
+}

--- a/src/test/java/org/springframework/data/r2dbc/repository/config/R2dbcRepositoriesRegistrarTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/config/R2dbcRepositoriesRegistrarTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.data.r2dbc.repository.config;
 
 import static org.mockito.Mockito.*;

--- a/src/test/java/org/springframework/data/r2dbc/repository/config/R2dbcRepositoryConfigurationExtensionUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/config/R2dbcRepositoryConfigurationExtensionUnitTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.repository.config;
+
+import static org.junit.Assert.*;
+
+import java.util.Collection;
+
+import org.junit.Test;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.type.StandardAnnotationMetadata;
+import org.springframework.data.r2dbc.repository.R2dbcRepository;
+import org.springframework.data.relational.core.mapping.Table;
+import org.springframework.data.repository.config.AnnotationRepositoryConfigurationSource;
+import org.springframework.data.repository.config.RepositoryConfiguration;
+import org.springframework.data.repository.config.RepositoryConfigurationSource;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+
+/**
+ * Unit tests for {@link R2dbcRepositoryConfigurationExtension}.
+ *
+ * @author Mark Paluch
+ */
+public class R2dbcRepositoryConfigurationExtensionUnitTests {
+
+	StandardAnnotationMetadata metadata = new StandardAnnotationMetadata(Config.class, true);
+	ResourceLoader loader = new PathMatchingResourcePatternResolver();
+	Environment environment = new StandardEnvironment();
+	BeanDefinitionRegistry registry = new DefaultListableBeanFactory();
+
+	RepositoryConfigurationSource configurationSource = new AnnotationRepositoryConfigurationSource(metadata,
+			EnableR2dbcRepositories.class, loader, environment, registry);
+
+	@Test // gh-13
+	public void isStrictMatchIfDomainTypeIsAnnotatedWithDocument() {
+
+		R2dbcRepositoryConfigurationExtension extension = new R2dbcRepositoryConfigurationExtension();
+		assertHasRepo(SampleRepository.class, extension.getRepositoryConfigurations(configurationSource, loader, true));
+	}
+
+	@Test // gh-13
+	public void isStrictMatchIfRepositoryExtendsStoreSpecificBase() {
+
+		R2dbcRepositoryConfigurationExtension extension = new R2dbcRepositoryConfigurationExtension();
+		assertHasRepo(StoreRepository.class, extension.getRepositoryConfigurations(configurationSource, loader, true));
+	}
+
+	@Test // gh-13
+	public void isNotStrictMatchIfDomainTypeIsNotAnnotatedWithDocument() {
+
+		R2dbcRepositoryConfigurationExtension extension = new R2dbcRepositoryConfigurationExtension();
+		assertDoesNotHaveRepo(UnannotatedRepository.class,
+				extension.getRepositoryConfigurations(configurationSource, loader, true));
+	}
+
+	private static void assertHasRepo(Class<?> repositoryInterface,
+			Collection<RepositoryConfiguration<RepositoryConfigurationSource>> configs) {
+
+		for (RepositoryConfiguration<?> config : configs) {
+			if (config.getRepositoryInterface().equals(repositoryInterface.getName())) {
+				return;
+			}
+		}
+
+		fail("Expected to find config for repository interface ".concat(repositoryInterface.getName()).concat(" but got ")
+				.concat(configs.toString()));
+	}
+
+	private static void assertDoesNotHaveRepo(Class<?> repositoryInterface,
+			Collection<RepositoryConfiguration<RepositoryConfigurationSource>> configs) {
+
+		for (RepositoryConfiguration<?> config : configs) {
+			if (config.getRepositoryInterface().equals(repositoryInterface.getName())) {
+				fail("Expected not to find config for repository interface ".concat(repositoryInterface.getName()));
+			}
+		}
+	}
+
+	@EnableR2dbcRepositories(considerNestedRepositories = true)
+	static class Config {}
+
+	@Table("sample")
+	static class Sample {}
+
+	static class Store {}
+
+	interface SampleRepository extends ReactiveCrudRepository<Sample, Long> {}
+
+	interface UnannotatedRepository extends ReactiveCrudRepository<Store, Long> {}
+
+	interface StoreRepository extends R2dbcRepository<Store, Long> {}
+}

--- a/src/test/java/org/springframework/data/r2dbc/repository/config/R2dbcRepositoryConfigurationExtensionUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/config/R2dbcRepositoryConfigurationExtensionUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.type.StandardAnnotationMetadata;
 import org.springframework.data.r2dbc.repository.R2dbcRepository;
 import org.springframework.data.relational.core.mapping.Table;
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.config.AnnotationRepositoryConfigurationSource;
 import org.springframework.data.repository.config.RepositoryConfiguration;
 import org.springframework.data.repository.config.RepositoryConfigurationSource;
@@ -38,6 +39,7 @@ import org.springframework.data.repository.reactive.ReactiveCrudRepository;
  * Unit tests for {@link R2dbcRepositoryConfigurationExtension}.
  *
  * @author Mark Paluch
+ * @author Christoph Strobl
  */
 public class R2dbcRepositoryConfigurationExtensionUnitTests {
 
@@ -68,6 +70,14 @@ public class R2dbcRepositoryConfigurationExtensionUnitTests {
 
 		R2dbcRepositoryConfigurationExtension extension = new R2dbcRepositoryConfigurationExtension();
 		assertDoesNotHaveRepo(UnannotatedRepository.class,
+				extension.getRepositoryConfigurations(configurationSource, loader, true));
+	}
+
+	@Test // gh-13
+	public void doesNotHaveNonReactiveRepository() {
+
+		R2dbcRepositoryConfigurationExtension extension = new R2dbcRepositoryConfigurationExtension();
+		assertDoesNotHaveRepo(NonReactiveRepository.class,
 				extension.getRepositoryConfigurations(configurationSource, loader, true));
 	}
 
@@ -107,4 +117,6 @@ public class R2dbcRepositoryConfigurationExtensionUnitTests {
 	interface UnannotatedRepository extends ReactiveCrudRepository<Store, Long> {}
 
 	interface StoreRepository extends R2dbcRepository<Store, Long> {}
+
+	interface NonReactiveRepository extends CrudRepository<Sample, Long> {}
 }


### PR DESCRIPTION
e now provide an annotation-based activation model for R2DBC repositories. Configuration classes can be annotated with `@EnableR2dbcRepositories` and configuration infrastructure will scan for bean definitions to implement declared R2DBC repositories.

We also now provide an abstract R2DBC configuration that registers beans required for R2DBC's `DatabaseClient`.

---

Related tickets: #13, #16 