### PR TITLE
 #15 - Add BindMarkers abstraction.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<version>1.0.0.gh-15-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC.</description>

--- a/src/main/java/org/springframework/data/r2dbc/dialect/BindMarker.java
+++ b/src/main/java/org/springframework/data/r2dbc/dialect/BindMarker.java
@@ -1,0 +1,42 @@
+package org.springframework.data.r2dbc.dialect;
+
+import io.r2dbc.spi.Statement;
+
+/**
+ * A bind marker represents a single bindable parameter within a query. Bind markers are dialect-specific and provide a
+ * {@link #getPlaceholder() placeholder} that is used in the actual query.
+ *
+ * @author Mark Paluch
+ * @see Statement#bind
+ * @see BindMarkers
+ * @see BindMarkersFactory
+ */
+public interface BindMarker {
+
+	/**
+	 * Returns the database-specific placeholder for a given substitution.
+	 *
+	 * @return the database-specific placeholder for a given substitution.
+	 */
+	String getPlaceholder();
+
+	/**
+	 * Bind the given {@code value} to the {@link Statement} using the underlying binding strategy.
+	 *
+	 * @param statement the statement to bind the value to.
+	 * @param value the actual value. Must not be {@literal null}. Use {@link #bindNull(Statement, Class)} for
+	 *          {@literal null} values.
+	 * @see Statement#bind
+	 */
+	void bindValue(Statement<?> statement, Object value);
+
+	/**
+	 * Bind a {@literal null} value to the {@link Statement} using the underlying binding strategy.
+	 *
+	 * @param statement the statement to bind the value to.
+	 * @param valueType value type, must not be {@literal null}.
+	 * @see Statement#bindNull
+	 */
+
+	void bindNull(Statement<?> statement, Class<?> valueType);
+}

--- a/src/main/java/org/springframework/data/r2dbc/dialect/BindMarkers.java
+++ b/src/main/java/org/springframework/data/r2dbc/dialect/BindMarkers.java
@@ -24,13 +24,13 @@ public interface BindMarkers {
 	BindMarker next();
 
 	/**
-	 * Creates a new {@link BindMarker} that accepts a {@code nameHint}. Implementations are allowed to consider/ignore
+	 * Creates a new {@link BindMarker} that accepts a {@code hint}. Implementations are allowed to consider/ignore/filter
 	 * the name hint to create more expressive bind markers.
 	 *
-	 * @param nameHint an optional name hint.
+	 * @param hint an optional name hint that can be used as part of the bind marker.
 	 * @return a new {@link BindMarker}.
 	 */
-	default BindMarker next(String nameHint) {
+	default BindMarker next(String hint) {
 		return next();
 	}
 }

--- a/src/main/java/org/springframework/data/r2dbc/dialect/BindMarkers.java
+++ b/src/main/java/org/springframework/data/r2dbc/dialect/BindMarkers.java
@@ -1,0 +1,36 @@
+package org.springframework.data.r2dbc.dialect;
+
+/**
+ * Bind markers represent placeholders in SQL queries for substitution for an actual parameter. Using bind markers
+ * allows creating safe queries so query strings are not required to contain escaped values but rather the driver
+ * encodes parameter in the appropriate representation.
+ * <p/>
+ * {@link BindMarkers} is stateful and can be only used for a single binding pass of one or more parameters. It
+ * maintains bind indexes/bind parameter names.
+ *
+ * @author Mark Paluch
+ * @see BindMarker
+ * @see BindMarkersFactory
+ * @see io.r2dbc.spi.Statement#bind
+ */
+@FunctionalInterface
+public interface BindMarkers {
+
+	/**
+	 * Creates a new {@link BindMarker}.
+	 *
+	 * @return a new {@link BindMarker}.
+	 */
+	BindMarker next();
+
+	/**
+	 * Creates a new {@link BindMarker} that accepts a {@code nameHint}. Implementations are allowed to consider/ignore
+	 * the name hint to create more expressive bind markers.
+	 *
+	 * @param nameHint an optional name hint.
+	 * @return a new {@link BindMarker}.
+	 */
+	default BindMarker next(String nameHint) {
+		return next();
+	}
+}

--- a/src/main/java/org/springframework/data/r2dbc/dialect/BindMarkersFactory.java
+++ b/src/main/java/org/springframework/data/r2dbc/dialect/BindMarkersFactory.java
@@ -1,0 +1,53 @@
+package org.springframework.data.r2dbc.dialect;
+
+import org.springframework.util.Assert;
+
+/**
+ * This class creates new {@link BindMarkers} instances to bind parameter for a specific {@link io.r2dbc.spi.Statement}.
+ *
+ * @author Mark Paluch
+ * @see BindMarkers
+ * @see io.r2dbc.spi.Statement
+ */
+@FunctionalInterface
+public interface BindMarkersFactory {
+
+	/**
+	 * Create a new {@link BindMarkers} instance.
+	 *
+	 * @return a new {@link BindMarkers} instance.
+	 */
+	BindMarkers create();
+
+	/**
+	 * Create index-based {@link BindMarkers}.
+	 *
+	 * @param prefix bind parameter prefix.
+	 * @param beginWith the first index to use.
+	 * @return a {@link BindMarkersFactory} using {@code prefix} and {@code beginWith}.
+	 */
+	static BindMarkersFactory indexed(String prefix, int beginWith) {
+
+		Assert.notNull(prefix, "Prefix must not be null!");
+		return () -> new IndexedBindMarkers(prefix, beginWith);
+	}
+
+	/**
+	 * Create named {@link BindMarkers}. Named bind markers can support {@link BindMarkers#next(String) name hints}.
+	 * Typically, named markers use name hints. If no namehint is given, named bind markers use a counter to generate
+	 * unique bind markers.
+	 *
+	 * @param prefix bind parameter prefix.
+	 * @param indexPrefix prefix for bind markers that were created by incrementing a counter to generate a unique bind
+	 *          marker.
+	 * @param nameLimit maximal length of parameter names when using name hints.
+	 * @return a {@link BindMarkersFactory} using {@code prefix} and {@code beginWith}.
+	 */
+	static BindMarkersFactory named(String prefix, String indexPrefix, int nameLimit) {
+
+		Assert.notNull(prefix, "Prefix must not be null!");
+		Assert.notNull(indexPrefix, "Index prefix must not be null!");
+
+		return () -> new NamedBindMarkers(prefix, indexPrefix, nameLimit);
+	}
+}

--- a/src/main/java/org/springframework/data/r2dbc/dialect/BindMarkersFactory.java
+++ b/src/main/java/org/springframework/data/r2dbc/dialect/BindMarkersFactory.java
@@ -1,9 +1,16 @@
 package org.springframework.data.r2dbc.dialect;
 
+import java.util.function.Function;
+
 import org.springframework.util.Assert;
 
 /**
  * This class creates new {@link BindMarkers} instances to bind parameter for a specific {@link io.r2dbc.spi.Statement}.
+ * <p/>
+ * Bind markers can be typically represented as placeholder and identifier. Placeholders are used within the query to
+ * execute so the underlying database system can substitute the placeholder with the actual value. Identifiers are used
+ * in R2DBC drivers to bind a value to a bind marker. Identifiers are typically a part of an entire bind marker when
+ * using indexed or named bind markers.
  *
  * @author Mark Paluch
  * @see BindMarkers
@@ -20,11 +27,15 @@ public interface BindMarkersFactory {
 	BindMarkers create();
 
 	/**
-	 * Create index-based {@link BindMarkers}.
+	 * Create index-based {@link BindMarkers} using indexes to bind parameters. Allow customization of the bind marker
+	 * placeholder {@code prefix} to represent the bind marker as placeholder within the query.
 	 *
-	 * @param prefix bind parameter prefix.
+	 * @param prefix bind parameter prefix that is included in {@link BindMarker#getPlaceholder()} but not the actual
+	 *          identifier.
 	 * @param beginWith the first index to use.
 	 * @return a {@link BindMarkersFactory} using {@code prefix} and {@code beginWith}.
+	 * @see io.r2dbc.spi.Statement#bindNull(int, Class)
+	 * @see io.r2dbc.spi.Statement#bind(int, Object)
 	 */
 	static BindMarkersFactory indexed(String prefix, int beginWith) {
 
@@ -33,21 +44,49 @@ public interface BindMarkersFactory {
 	}
 
 	/**
-	 * Create named {@link BindMarkers}. Named bind markers can support {@link BindMarkers#next(String) name hints}.
-	 * Typically, named markers use name hints. If no namehint is given, named bind markers use a counter to generate
-	 * unique bind markers.
+	 * Create named {@link BindMarkers} using identifiers to bind parameters. Named bind markers can support
+	 * {@link BindMarkers#next(String) name hints}. If no {@link BindMarkers#next(String) hint} is given, named bind
+	 * markers can use a counter or a random value source to generate unique bind markers.
+	 * <p/>
+	 * Allow customization of the bind marker placeholder {@code prefix} and {@code namePrefix} to represent the bind
+	 * marker as placeholder within the query.
 	 *
-	 * @param prefix bind parameter prefix.
-	 * @param indexPrefix prefix for bind markers that were created by incrementing a counter to generate a unique bind
-	 *          marker.
-	 * @param nameLimit maximal length of parameter names when using name hints.
+	 * @param prefix bind parameter prefix that is included in {@link BindMarker#getPlaceholder()} but not the actual
+	 *          identifier.
+	 * @param namePrefix prefix for bind marker name that is included in {@link BindMarker#getPlaceholder()} and the
+	 *          actual identifier.
+	 * @param maxLength maximal length of parameter names when using name hints.
 	 * @return a {@link BindMarkersFactory} using {@code prefix} and {@code beginWith}.
+	 * @see io.r2dbc.spi.Statement#bindNull(Object, Class)
+	 * @see io.r2dbc.spi.Statement#bind(Object, Object)
 	 */
-	static BindMarkersFactory named(String prefix, String indexPrefix, int nameLimit) {
+	static BindMarkersFactory named(String prefix, String namePrefix, int maxLength) {
+		return named(prefix, namePrefix, maxLength, Function.identity());
+	}
+
+	/**
+	 * Create named {@link BindMarkers} using identifiers to bind parameters. Named bind markers can support
+	 * {@link BindMarkers#next(String) name hints}. If no {@link BindMarkers#next(String) hint} is given, named bind
+	 * markers can use a counter or a random value source to generate unique bind markers.
+	 *
+	 * @param prefix bind parameter prefix that is included in {@link BindMarker#getPlaceholder()} but not the actual
+	 *          identifier.
+	 * @param namePrefix prefix for bind marker name that is included in {@link BindMarker#getPlaceholder()} and the
+	 *          actual identifier.
+	 * @param maxLength maximal length of parameter names when using name hints.
+	 * @param hintFilterFunction filter {@link Function} to consider database-specific limitations in bind marker/variable
+	 *          names such as ASCII chars only.
+	 * @return a {@link BindMarkersFactory} using {@code prefix} and {@code beginWith}.
+	 * @see io.r2dbc.spi.Statement#bindNull(Object, Class)
+	 * @see io.r2dbc.spi.Statement#bind(Object, Object)
+	 */
+	static BindMarkersFactory named(String prefix, String namePrefix, int maxLength,
+			Function<String, String> hintFilterFunction) {
 
 		Assert.notNull(prefix, "Prefix must not be null!");
-		Assert.notNull(indexPrefix, "Index prefix must not be null!");
+		Assert.notNull(namePrefix, "Index prefix must not be null!");
+		Assert.notNull(hintFilterFunction, "Hint filter function must not be null!");
 
-		return () -> new NamedBindMarkers(prefix, indexPrefix, nameLimit);
+		return () -> new NamedBindMarkers(prefix, namePrefix, maxLength, hintFilterFunction);
 	}
 }

--- a/src/main/java/org/springframework/data/r2dbc/dialect/IndexedBindMarkers.java
+++ b/src/main/java/org/springframework/data/r2dbc/dialect/IndexedBindMarkers.java
@@ -1,0 +1,87 @@
+package org.springframework.data.r2dbc.dialect;
+
+import io.r2dbc.spi.Statement;
+
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
+/**
+ * Index-based bind marker. This implementation creates indexed bind markers using a numeric index and an optional
+ * prefix for bind markers to be represented within the query string.
+ *
+ * @author Mark Paluch
+ */
+class IndexedBindMarkers implements BindMarkers {
+
+	private static final AtomicIntegerFieldUpdater<org.springframework.data.r2dbc.dialect.IndexedBindMarkers> COUNTER_INCREMENTER = AtomicIntegerFieldUpdater
+			.newUpdater(org.springframework.data.r2dbc.dialect.IndexedBindMarkers.class, "counter");
+
+	// access via COUNTER_INCREMENTER
+	@SuppressWarnings("unused") private volatile int counter;
+
+	private final String prefix;
+
+	/**
+	 * Creates a new {@link IndexedBindMarker} instance given {@code prefix} and {@code beginWith}.
+	 *
+	 * @param prefix bind parameter prefix.
+	 * @param beginWith the first index to use.
+	 */
+	IndexedBindMarkers(String prefix, int beginWith) {
+		this.counter = beginWith;
+		this.prefix = prefix;
+	}
+
+	/* 
+	 * (non-Javadoc)
+	 * @see org.springframework.data.r2dbc.dialect.BindMarkers#next()
+	 */
+	@Override
+	public BindMarker next() {
+
+		int index = COUNTER_INCREMENTER.getAndIncrement(this);
+
+		return new IndexedBindMarker(prefix + "" + index, index);
+	}
+
+	/**
+	 * A single indexed bind marker.
+	 */
+	static class IndexedBindMarker implements BindMarker {
+
+		private final String placeholder;
+
+		private int index;
+
+		IndexedBindMarker(String placeholder, int index) {
+			this.placeholder = placeholder;
+			this.index = index;
+		}
+
+		/* 
+		 * (non-Javadoc)
+		 * @see org.springframework.data.r2dbc.dialect.BindMarker#getPlaceholder()
+		 */
+		@Override
+		public String getPlaceholder() {
+			return placeholder;
+		}
+
+		/* 
+		 * (non-Javadoc)
+		 * @see org.springframework.data.r2dbc.dialect.BindMarker#bindValue(io.r2dbc.spi.Statement, java.lang.Object)
+		 */
+		@Override
+		public void bindValue(Statement<?> statement, Object value) {
+			statement.bind(this.index, value);
+		}
+
+		/* 
+		 * (non-Javadoc)
+		 * @see org.springframework.data.r2dbc.dialect.BindMarker#bindNull(io.r2dbc.spi.Statement, java.lang.Class)
+		 */
+		@Override
+		public void bindNull(Statement<?> statement, Class<?> valueType) {
+			statement.bindNull(this.index, valueType);
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/r2dbc/dialect/NamedBindMarkers.java
+++ b/src/main/java/org/springframework/data/r2dbc/dialect/NamedBindMarkers.java
@@ -1,0 +1,129 @@
+package org.springframework.data.r2dbc.dialect;
+
+import io.r2dbc.spi.Statement;
+
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
+import org.springframework.util.Assert;
+
+/**
+ * Name-based bind markers.
+ *
+ * @author Mark Paluch
+ */
+class NamedBindMarkers implements BindMarkers {
+
+	private static final AtomicIntegerFieldUpdater<NamedBindMarkers> COUNTER_INCREMENTER = AtomicIntegerFieldUpdater
+			.newUpdater(NamedBindMarkers.class, "counter");
+
+	// access via COUNTER_INCREMENTER
+	@SuppressWarnings("unused") private volatile int counter;
+
+	private final String prefix;
+
+	private final String indexPrefix;
+
+	private final int nameLimit;
+
+	NamedBindMarkers(String prefix, String indexPrefix, int nameLimit) {
+
+		this.prefix = prefix;
+		this.indexPrefix = indexPrefix;
+		this.nameLimit = nameLimit;
+	}
+
+	@Override
+	public BindMarker next() {
+
+		String name = nextName();
+
+		return new NamedBindMarker(prefix + name, name);
+	}
+
+	@Override
+	public BindMarker next(String nameHint) {
+
+		Assert.notNull(nameHint, "Name hint must not be null");
+
+		String name = nextName();
+
+		String filteredNameHint = filter(nameHint);
+
+		if (!filteredNameHint.isEmpty()) {
+			name += "_" + filteredNameHint;
+		}
+
+		if (name.length() > nameLimit) {
+			name = name.substring(0, nameLimit);
+		}
+
+		return new NamedBindMarker(prefix + name, name);
+	}
+
+	private String nextName() {
+
+		int index = COUNTER_INCREMENTER.getAndIncrement(this);
+		return indexPrefix + index;
+	}
+
+	private static String filter(CharSequence input) {
+
+		StringBuilder builder = new StringBuilder();
+
+		for (int i = 0; i < input.length(); i++) {
+
+			char ch = input.charAt(i);
+
+			// ascii letter or digit
+			if (Character.isLetterOrDigit(ch) && ch < 127) {
+				builder.append(ch);
+			}
+
+		}
+
+		return builder.toString();
+	}
+
+	/**
+	 * A single named bind marker.
+	 */
+	static class NamedBindMarker implements BindMarker {
+
+		private final String placeholder;
+
+		private final String identifier;
+
+		NamedBindMarker(String placeholder, String identifier) {
+
+			this.placeholder = placeholder;
+			this.identifier = identifier;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.r2dbc.dialect.BindMarker#getPlaceholder()
+		 */
+		@Override
+		public String getPlaceholder() {
+			return this.placeholder;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.r2dbc.dialect.BindMarker#bindValue(io.r2dbc.spi.Statement, java.lang.Object)
+		 */
+		@Override
+		public void bindValue(Statement<?> statement, Object value) {
+			statement.bind(this.identifier, value);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.r2dbc.dialect.BindMarker#bindNull(io.r2dbc.spi.Statement, java.lang.Class)
+		 */
+		@Override
+		public void bindNull(Statement<?> statement, Class<?> valueType) {
+			statement.bindNull(this.identifier, valueType);
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/r2dbc/dialect/package-info.java
+++ b/src/main/java/org/springframework/data/r2dbc/dialect/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Dialects abstract the SQL dialect of the underlying database.
+ */
+@NonNullApi
+package org.springframework.data.r2dbc.dialect;
+
+import org.springframework.lang.NonNullApi;

--- a/src/test/java/org/springframework/data/r2dbc/dialect/IndexedBindMarkersUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/dialect/IndexedBindMarkersUnitTests.java
@@ -29,13 +29,18 @@ public class IndexedBindMarkersUnitTests {
 	@Test // gh-15
 	public void nextShouldIncrementBindMarker() {
 
-		BindMarkers bindMarkers = BindMarkersFactory.indexed("$", 0).create();
+		String[] prefixes = { "$", "?" };
 
-		BindMarker marker1 = bindMarkers.next();
-		BindMarker marker2 = bindMarkers.next();
+		for (String prefix : prefixes) {
 
-		assertThat(marker1.getPlaceholder()).isEqualTo("$0");
-		assertThat(marker2.getPlaceholder()).isEqualTo("$1");
+			BindMarkers bindMarkers = BindMarkersFactory.indexed(prefix, 0).create();
+
+			BindMarker marker1 = bindMarkers.next();
+			BindMarker marker2 = bindMarkers.next();
+
+			assertThat(marker1.getPlaceholder()).isEqualTo(prefix + "0");
+			assertThat(marker2.getPlaceholder()).isEqualTo(prefix + "1");
+		}
 	}
 
 	@Test // gh-15

--- a/src/test/java/org/springframework/data/r2dbc/dialect/IndexedBindMarkersUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/dialect/IndexedBindMarkersUnitTests.java
@@ -1,0 +1,68 @@
+package org.springframework.data.r2dbc.dialect;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.r2dbc.spi.Statement;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link IndexedBindMarkers}.
+ *
+ * @author Mark Paluch
+ */
+public class IndexedBindMarkersUnitTests {
+
+	@Test // gh-15
+	public void shouldCreateNewBindMarkers() {
+
+		BindMarkersFactory factory = BindMarkersFactory.indexed("$", 0);
+
+		BindMarkers bindMarkers1 = factory.create();
+		BindMarkers bindMarkers2 = factory.create();
+
+		assertThat(bindMarkers1.next().getPlaceholder()).isEqualTo("$0");
+		assertThat(bindMarkers2.next().getPlaceholder()).isEqualTo("$0");
+	}
+
+	@Test // gh-15
+	public void nextShouldIncrementBindMarker() {
+
+		BindMarkers bindMarkers = BindMarkersFactory.indexed("$", 0).create();
+
+		BindMarker marker1 = bindMarkers.next();
+		BindMarker marker2 = bindMarkers.next();
+
+		assertThat(marker1.getPlaceholder()).isEqualTo("$0");
+		assertThat(marker2.getPlaceholder()).isEqualTo("$1");
+	}
+
+	@Test // gh-15
+	public void bindValueShouldBindByIndex() {
+
+		Statement<?> statement = mock(Statement.class);
+
+		BindMarkers bindMarkers = BindMarkersFactory.indexed("$", 0).create();
+
+		bindMarkers.next().bindValue(statement, "foo");
+		bindMarkers.next().bindValue(statement, "bar");
+
+		verify(statement).bind(0, "foo");
+		verify(statement).bind(1, "bar");
+	}
+
+	@Test // gh-15
+	public void bindNullShouldBindByIndex() {
+
+		Statement<?> statement = mock(Statement.class);
+
+		BindMarkers bindMarkers = BindMarkersFactory.indexed("$", 0).create();
+
+		bindMarkers.next(); // ignore
+
+		bindMarkers.next().bindNull(statement, Integer.class);
+
+		verify(statement).bindNull(1, Integer.class);
+	}
+}

--- a/src/test/java/org/springframework/data/r2dbc/dialect/NamedBindMarkersUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/dialect/NamedBindMarkersUnitTests.java
@@ -1,0 +1,90 @@
+package org.springframework.data.r2dbc.dialect;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.r2dbc.spi.Statement;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link NamedBindMarkers}.
+ *
+ * @author Mark Paluch
+ */
+public class NamedBindMarkersUnitTests {
+
+	@Test // gh-15
+	public void shouldCreateNewBindMarkers() {
+
+		BindMarkersFactory factory = BindMarkersFactory.named("@", "p", 32);
+
+		BindMarkers bindMarkers1 = factory.create();
+		BindMarkers bindMarkers2 = factory.create();
+
+		assertThat(bindMarkers1.next().getPlaceholder()).isEqualTo("@p0");
+		assertThat(bindMarkers2.next().getPlaceholder()).isEqualTo("@p0");
+	}
+
+	@Test // gh-15
+	public void nextShouldIncrementBindMarker() {
+
+		BindMarkers bindMarkers = BindMarkersFactory.named("@", "p", 32).create();
+
+		BindMarker marker1 = bindMarkers.next();
+		BindMarker marker2 = bindMarkers.next();
+
+		assertThat(marker1.getPlaceholder()).isEqualTo("@p0");
+		assertThat(marker2.getPlaceholder()).isEqualTo("@p1");
+	}
+
+	@Test // gh-15
+	public void nextShouldConsiderNameHint() {
+
+		BindMarkers bindMarkers = BindMarkersFactory.named("@", "p", 32).create();
+
+		BindMarker marker1 = bindMarkers.next("foo.bar?");
+		BindMarker marker2 = bindMarkers.next();
+
+		assertThat(marker1.getPlaceholder()).isEqualTo("@p0_foobar");
+		assertThat(marker2.getPlaceholder()).isEqualTo("@p1");
+	}
+
+	@Test // gh-15
+	public void nextShouldConsiderNameLimit() {
+
+		BindMarkers bindMarkers = BindMarkersFactory.named("@", "p", 10).create();
+
+		BindMarker marker1 = bindMarkers.next("123456789");
+
+		assertThat(marker1.getPlaceholder()).isEqualTo("@p0_1234567");
+	}
+
+	@Test // gh-15
+	public void bindValueShouldBindByName() {
+
+		Statement<?> statement = mock(Statement.class);
+
+		BindMarkers bindMarkers = BindMarkersFactory.named("@", "p", 32).create();
+
+		bindMarkers.next().bindValue(statement, "foo");
+		bindMarkers.next().bindValue(statement, "bar");
+
+		verify(statement).bind("p0", "foo");
+		verify(statement).bind("p1", "bar");
+	}
+
+	@Test // gh-15
+	public void bindNullShouldBindByName() {
+
+		Statement<?> statement = mock(Statement.class);
+
+		BindMarkers bindMarkers = BindMarkersFactory.named("@", "p", 32).create();
+
+		bindMarkers.next(); // ignore
+
+		bindMarkers.next().bindNull(statement, Integer.class);
+
+		verify(statement).bindNull("p1", Integer.class);
+	}
+}


### PR DESCRIPTION
We now expose a bind marker API that allows modeling a vendor-specific bind marker strategy. The currently supported database systems (Postgres, MsSql) implement indexed respective named strategies that differ in how placeholders and identifiers are generated.

---

Related ticket: #15.