### PR TITLE
Remove restriction on CollectionLike types

### DIFF
--- a/src/main/java/org/springframework/data/r2dbc/function/convert/EntityRowMapper.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/convert/EntityRowMapper.java
@@ -66,10 +66,7 @@ public class EntityRowMapper<T> implements BiFunction<Row, RowMetadata, T> {
 				continue;
 			}
 
-			if (property.isCollectionLike()) {
-				throw new UnsupportedOperationException();
-			} else if (property.isMap()) {
-
+			if (property.isMap()) {
 				throw new UnsupportedOperationException();
 			} else {
 				propertyAccessor.setProperty(property, readFrom(row, property, ""));


### PR DESCRIPTION
Now that R2DBC 1.0M6 supports array types, allow CollectionLike types to be handled in EntityRowMapper. I verified that this works for both arrays and collection types such as List<String>.