### PR TITLE
#30 - Add custom conversion support to write array-typed values.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<version>1.0.0.gh-30-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC.</description>

--- a/src/main/java/org/springframework/data/r2dbc/config/AbstractR2dbcConfiguration.java
+++ b/src/main/java/org/springframework/data/r2dbc/config/AbstractR2dbcConfiguration.java
@@ -118,7 +118,7 @@ public abstract class AbstractR2dbcConfiguration {
 	}
 
 	/**
-	 * Creates a {@link ReactiveDataAccessStrategy} using the configured {@link #r2dbcMappingContext(Optional)
+	 * Creates a {@link ReactiveDataAccessStrategy} using the configured {@link #r2dbcMappingContext(Optional, R2dbcCustomConversions)}
 	 * RelationalMappingContext}.
 	 *
 	 * @param mappingContext the configured {@link RelationalMappingContext}.

--- a/src/main/java/org/springframework/data/r2dbc/dialect/ArrayColumns.java
+++ b/src/main/java/org/springframework/data/r2dbc/dialect/ArrayColumns.java
@@ -1,0 +1,53 @@
+package org.springframework.data.r2dbc.dialect;
+
+/**
+ * Interface declaring methods that express how a dialect supports array-typed columns.
+ *
+ * @author Mark Paluch
+ */
+public interface ArrayColumns {
+
+	/**
+	 * Returns {@literal true} if the dialect supports array-typed columns.
+	 *
+	 * @return {@literal true} if the dialect supports array-typed columns.
+	 */
+	boolean isSupported();
+
+	/**
+	 * Translate the {@link Class user type} of an array into the dialect-specific type. This method considers only the
+	 * component type.
+	 *
+	 * @param userType component type of the array.
+	 * @return the dialect-supported array type.
+	 * @throws UnsupportedOperationException if array typed columns are not supported.
+	 * @throws IllegalArgumentException if the {@code userType} is not a supported array type.
+	 */
+	Class<?> getArrayType(Class<?> userType);
+
+	/**
+	 * Default {@link ArrayColumns} implementation for dialects that do not support array-typed columns.
+	 */
+	enum Unsupported implements ArrayColumns {
+
+		INSTANCE;
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.r2dbc.dialect.ArrayColumns#isSupported()
+		 */
+		@Override
+		public boolean isSupported() {
+			return false;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.r2dbc.dialect.ArrayColumns#getArrayType(java.lang.Class)
+		 */
+		@Override
+		public Class<?> getArrayType(Class<?> userType) {
+			throw new UnsupportedOperationException("Array types not supported");
+		}
+	}
+}

--- a/src/main/java/org/springframework/data/r2dbc/dialect/Dialect.java
+++ b/src/main/java/org/springframework/data/r2dbc/dialect/Dialect.java
@@ -1,5 +1,11 @@
 package org.springframework.data.r2dbc.dialect;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+
+import org.springframework.data.mapping.model.SimpleTypeHolder;
+
 /**
  * Represents a dialect that is implemented by a particular database.
  *
@@ -27,9 +33,40 @@ public interface Dialect {
 	String generatedKeysClause();
 
 	/**
+	 * Return a collection of types that are natively supported by this database/driver. Defaults to
+	 * {@link Collections#emptySet()}.
+	 *
+	 * @return a collection of types that are natively supported by this database/driver. Defaults to
+	 *         {@link Collections#emptySet()}.
+	 */
+	default Collection<? extends Class<?>> getSimpleTypes() {
+		return Collections.emptySet();
+	}
+
+	/**
+	 * Return the {@link SimpleTypeHolder} for this dialect.
+	 *
+	 * @return the {@link SimpleTypeHolder} for this dialect.
+	 * @see #getSimpleTypes()
+	 */
+	default SimpleTypeHolder getSimpleTypeHolder() {
+		return new SimpleTypeHolder(new HashSet<>(getSimpleTypes()), true);
+	}
+
+	/**
 	 * Return the {@link LimitClause} used by this dialect.
 	 *
 	 * @return the {@link LimitClause} used by this dialect.
 	 */
 	LimitClause limit();
+
+	/**
+	 * Returns {@literal true} whether this dialect supports array-typed column. Collection-typed columns can map their
+	 * content to native array types.
+	 *
+	 * @return {@literal true} whether this dialect supports array-typed columns.
+	 */
+	default boolean supportsArrayColumns() {
+		return false;
+	}
 }

--- a/src/main/java/org/springframework/data/r2dbc/dialect/Dialect.java
+++ b/src/main/java/org/springframework/data/r2dbc/dialect/Dialect.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.HashSet;
 
 import org.springframework.data.mapping.model.SimpleTypeHolder;
+import org.springframework.data.r2dbc.dialect.ArrayColumns.Unsupported;
 
 /**
  * Represents a dialect that is implemented by a particular database.
@@ -61,12 +62,11 @@ public interface Dialect {
 	LimitClause limit();
 
 	/**
-	 * Returns {@literal true} whether this dialect supports array-typed column. Collection-typed columns can map their
-	 * content to native array types.
+	 * Returns the array support object that describes how array-typed columns are supported by this dialect.
 	 *
-	 * @return {@literal true} whether this dialect supports array-typed columns.
+	 * @return the array support object that describes how array-typed columns are supported by this dialect.
 	 */
-	default boolean supportsArrayColumns() {
-		return false;
+	default ArrayColumns getArraySupport() {
+		return Unsupported.INSTANCE;
 	}
 }

--- a/src/main/java/org/springframework/data/r2dbc/dialect/PostgresDialect.java
+++ b/src/main/java/org/springframework/data/r2dbc/dialect/PostgresDialect.java
@@ -1,11 +1,24 @@
 package org.springframework.data.r2dbc.dialect;
 
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
 /**
  * An SQL dialect for Postgres.
  *
  * @author Mark Paluch
  */
 public class PostgresDialect implements Dialect {
+
+	private static final Set<Class<?>> SIMPLE_TYPES = new HashSet<>(
+			Arrays.asList(List.class, Collection.class, String[].class, UUID.class, URL.class, URI.class, InetAddress.class));
 
 	/**
 	 * Singleton instance.
@@ -64,10 +77,28 @@ public class PostgresDialect implements Dialect {
 
 	/*
 	 * (non-Javadoc)
+	 * @see org.springframework.data.r2dbc.dialect.Dialect#getSimpleTypesKeys()
+	 */
+	@Override
+	public Collection<? extends Class<?>> getSimpleTypes() {
+		return SIMPLE_TYPES;
+	}
+
+	/*
+	 * (non-Javadoc)
 	 * @see org.springframework.data.r2dbc.dialect.Dialect#limit()
 	 */
 	@Override
 	public LimitClause limit() {
 		return LIMIT_CLAUSE;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.r2dbc.dialect.Dialect#supportsArrayColumns()
+	 */
+	@Override
+	public boolean supportsArrayColumns() {
+		return true;
 	}
 }

--- a/src/main/java/org/springframework/data/r2dbc/dialect/SqlServerDialect.java
+++ b/src/main/java/org/springframework/data/r2dbc/dialect/SqlServerDialect.java
@@ -1,11 +1,19 @@
 package org.springframework.data.r2dbc.dialect;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
 /**
  * An SQL dialect for Microsoft SQL Server.
  *
  * @author Mark Paluch
  */
 public class SqlServerDialect implements Dialect {
+
+	private static final Set<Class<?>> SIMPLE_TYPES = new HashSet<>(Collections.singletonList(UUID.class));
 
 	/**
 	 * Singleton instance.
@@ -61,6 +69,15 @@ public class SqlServerDialect implements Dialect {
 	@Override
 	public String generatedKeysClause() {
 		return "select SCOPE_IDENTITY() AS GENERATED_KEYS";
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.r2dbc.dialect.Dialect#getSimpleTypesKeys()
+	 */
+	@Override
+	public Collection<? extends Class<?>> getSimpleTypes() {
+		return SIMPLE_TYPES;
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/r2dbc/function/DefaultReactiveDataAccessStrategy.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/DefaultReactiveDataAccessStrategy.java
@@ -261,11 +261,13 @@ public class DefaultReactiveDataAccessStrategy implements ReactiveDataAccessStra
 			}
 
 			if (!dialect.supportsArrayColumns()) {
+
 				throw new InvalidDataAccessResourceUsageException(
 						"Dialect " + dialect.getClass().getName() + " does not support array columns");
 			}
 
 			if (!property.isArray()) {
+
 				Object zeroLengthArray = Array.newInstance(property.getActualType(), 0);
 				return relationalConverter.getConversionService().convert(value, zeroLengthArray.getClass());
 			}

--- a/src/main/java/org/springframework/data/r2dbc/function/ReactiveDataAccessStrategy.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/ReactiveDataAccessStrategy.java
@@ -20,6 +20,7 @@ import io.r2dbc.spi.RowMetadata;
 import io.r2dbc.spi.Statement;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
 
@@ -48,6 +49,14 @@ public interface ReactiveDataAccessStrategy {
 	 * @return {@link SettableValue} that represent an {@code INSERT} of {@code object}.
 	 */
 	List<SettableValue> getValuesToInsert(Object object);
+
+	/**
+	 * Returns a {@link Map} that maps column names to a {@link SettableValue} value.
+	 *
+	 * @param object must not be {@literal null}.
+	 * @return
+	 */
+	Map<String, SettableValue> getColumnsToUpdate(Object object);
 
 	/**
 	 * Map the {@link Sort} object to apply field name mapping using {@link Class the type to read}.

--- a/src/main/java/org/springframework/data/r2dbc/function/convert/EntityRowMapper.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/convert/EntityRowMapper.java
@@ -66,10 +66,7 @@ public class EntityRowMapper<T> implements BiFunction<Row, RowMetadata, T> {
 				continue;
 			}
 
-			if (property.isCollectionLike()) {
-				throw new UnsupportedOperationException();
-			} else if (property.isMap()) {
-
+			if (property.isMap()) {
 				throw new UnsupportedOperationException();
 			} else {
 				propertyAccessor.setProperty(property, readFrom(row, property, ""));

--- a/src/main/java/org/springframework/data/r2dbc/function/convert/EntityRowMapper.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/convert/EntityRowMapper.java
@@ -96,7 +96,8 @@ public class EntityRowMapper<T> implements BiFunction<Row, RowMetadata, T> {
 				return readEntityFrom(row, property);
 			}
 
-			return converter.readValue(row.get(prefix + property.getColumnName()), property.getTypeInformation());
+			Object value = row.get(prefix + property.getColumnName());
+			return converter.readValue(value, property.getTypeInformation());
 
 		} catch (Exception o_O) {
 			throw new MappingException(String.format("Could not read property %s from result set!", property), o_O);
@@ -156,9 +157,7 @@ public class EntityRowMapper<T> implements BiFunction<Row, RowMetadata, T> {
 			String column = prefix + property.getColumnName();
 
 			try {
-
-				Object value = converter.readValue(resultSet.get(column), property.getTypeInformation());
-				return converter.getConversionService().convert(value, parameter.getType().getType());
+				return converter.getConversionService().convert(resultSet.get(column), parameter.getType().getType());
 			} catch (Exception o_O) {
 				throw new MappingException(String.format("Couldn't read column %s from Row.", column), o_O);
 			}

--- a/src/main/java/org/springframework/data/r2dbc/function/convert/MappingR2dbcConverter.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/convert/MappingR2dbcConverter.java
@@ -21,7 +21,6 @@ import io.r2dbc.spi.RowMetadata;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.BiFunction;
 
 import org.springframework.core.convert.ConversionService;
@@ -63,32 +62,6 @@ public class MappingR2dbcConverter {
 		Assert.notNull(converter, "RelationalConverter must not be null!");
 
 		this.relationalConverter = converter;
-	}
-
-	/**
-	 * Returns a {@link Map} that maps column names to an {@link Optional} value. Used {@link Optional#empty()} if the
-	 * underlying property is {@literal null}.
-	 *
-	 * @param object must not be {@literal null}.
-	 * @return
-	 */
-	public Map<String, SettableValue> getColumnsToUpdate(Object object) {
-
-		Assert.notNull(object, "Entity object must not be null!");
-
-		Class<?> userClass = ClassUtils.getUserClass(object);
-		RelationalPersistentEntity<?> entity = getMappingContext().getRequiredPersistentEntity(userClass);
-
-		Map<String, SettableValue> update = new LinkedHashMap<>();
-
-		PersistentPropertyAccessor propertyAccessor = entity.getPropertyAccessor(object);
-
-		for (RelationalPersistentProperty property : entity) {
-			update.put(property.getColumnName(),
-					new SettableValue(property.getColumnName(), propertyAccessor.getProperty(property), property.getType()));
-		}
-
-		return update;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/r2dbc/function/convert/R2dbcCustomConversions.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/convert/R2dbcCustomConversions.java
@@ -1,0 +1,26 @@
+package org.springframework.data.r2dbc.function.convert;
+
+import java.util.Collection;
+
+import org.springframework.data.convert.CustomConversions;
+
+/**
+ * Value object to capture custom conversion. {@link R2dbcCustomConversions} also act as factory for
+ * {@link org.springframework.data.mapping.model.SimpleTypeHolder}
+ *
+ * @author Mark Paluch
+ * @see CustomConversions
+ * @see org.springframework.data.mapping.model.SimpleTypeHolder
+ */
+public class R2dbcCustomConversions extends CustomConversions {
+
+	/**
+	 * Creates a new {@link CustomConversions} instance registering the given converters.
+	 *
+	 * @param storeConversions must not be {@literal null}.
+	 * @param converters must not be {@literal null}.
+	 */
+	public R2dbcCustomConversions(StoreConversions storeConversions, Collection<?> converters) {
+		super(storeConversions, converters);
+	}
+}

--- a/src/main/java/org/springframework/data/r2dbc/repository/config/R2dbcRepositoriesRegistrar.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/config/R2dbcRepositoriesRegistrar.java
@@ -24,7 +24,6 @@ import org.springframework.data.repository.config.RepositoryConfigurationExtensi
  * R2DBC-specific {@link org.springframework.context.annotation.ImportBeanDefinitionRegistrar}.
  *
  * @author Mark Paluch
- * @since 2.0
  */
 class R2dbcRepositoriesRegistrar extends RepositoryBeanDefinitionRegistrarSupport {
 

--- a/src/main/java/org/springframework/data/r2dbc/repository/support/SimpleR2dbcRepository.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/support/SimpleR2dbcRepository.java
@@ -71,7 +71,7 @@ public class SimpleR2dbcRepository<T, ID> implements ReactiveCrudRepository<T, I
 		}
 
 		Object id = entity.getRequiredId(objectToSave);
-		Map<String, SettableValue> columns = converter.getColumnsToUpdate(objectToSave);
+		Map<String, SettableValue> columns = accessStrategy.getColumnsToUpdate(objectToSave);
 		columns.remove(getIdColumnName()); // do not update the Id column.
 		String idColumnName = getIdColumnName();
 		BindIdOperation update = accessStrategy.updateById(entity.getTableName(), columns.keySet(), idColumnName);

--- a/src/test/java/org/springframework/data/r2dbc/dialect/PostgresDialectUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/dialect/PostgresDialectUnitTests.java
@@ -2,7 +2,11 @@ package org.springframework.data.r2dbc.dialect;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.Collection;
+import java.util.List;
+
 import org.junit.Test;
+import org.springframework.data.mapping.model.SimpleTypeHolder;
 
 /**
  * Unit tests for {@link PostgresDialect}.
@@ -21,5 +25,22 @@ public class PostgresDialectUnitTests {
 
 		assertThat(first.getPlaceholder()).isEqualTo("$1");
 		assertThat(second.getPlaceholder()).isEqualTo("$2");
+	}
+
+	@Test // gh-30
+	public void shouldConsiderCollectionTypesAsSimple() {
+
+		SimpleTypeHolder holder = PostgresDialect.INSTANCE.getSimpleTypeHolder();
+
+		assertThat(holder.isSimpleType(List.class)).isTrue();
+		assertThat(holder.isSimpleType(Collection.class)).isTrue();
+	}
+
+	@Test // gh-30
+	public void shouldConsiderStringArrayTypeAsSimple() {
+
+		SimpleTypeHolder holder = PostgresDialect.INSTANCE.getSimpleTypeHolder();
+
+		assertThat(holder.isSimpleType(String[].class)).isTrue();
 	}
 }

--- a/src/test/java/org/springframework/data/r2dbc/dialect/PostgresDialectUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/dialect/PostgresDialectUnitTests.java
@@ -42,5 +42,21 @@ public class PostgresDialectUnitTests {
 		SimpleTypeHolder holder = PostgresDialect.INSTANCE.getSimpleTypeHolder();
 
 		assertThat(holder.isSimpleType(String[].class)).isTrue();
+
+		@Test // gh-30
+		public void shouldConsiderIntArrayTypeAsSimple() {
+
+			SimpleTypeHolder holder = PostgresDialect.INSTANCE.getSimpleTypeHolder();
+
+			assertThat(holder.isSimpleType(int[].class)).isTrue();
+		}
+
+		@Test // gh-30
+		public void shouldConsiderIntegerArrayTypeAsSimple() {
+
+			SimpleTypeHolder holder = PostgresDialect.INSTANCE.getSimpleTypeHolder();
+
+			assertThat(holder.isSimpleType(Integer[].class)).isTrue();
+		}
 	}
 }

--- a/src/test/java/org/springframework/data/r2dbc/dialect/SqlServerDialectUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/dialect/SqlServerDialectUnitTests.java
@@ -2,7 +2,10 @@ package org.springframework.data.r2dbc.dialect;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.UUID;
+
 import org.junit.Test;
+import org.springframework.data.mapping.model.SimpleTypeHolder;
 
 /**
  * Unit tests for {@link SqlServerDialect}.
@@ -21,5 +24,13 @@ public class SqlServerDialectUnitTests {
 
 		assertThat(first.getPlaceholder()).isEqualTo("@P0");
 		assertThat(second.getPlaceholder()).isEqualTo("@P1_foobar");
+	}
+
+	@Test // gh-30
+	public void shouldConsiderUuidAsSimple() {
+
+		SimpleTypeHolder holder = SqlServerDialect.INSTANCE.getSimpleTypeHolder();
+
+		assertThat(holder.isSimpleType(UUID.class)).isTrue();
 	}
 }

--- a/src/test/java/org/springframework/data/r2dbc/dialect/SqlServerDialectUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/dialect/SqlServerDialectUnitTests.java
@@ -33,4 +33,13 @@ public class SqlServerDialectUnitTests {
 
 		assertThat(holder.isSimpleType(UUID.class)).isTrue();
 	}
+
+	@Test // gh-30
+	public void shouldNotSupportArrays() {
+
+		ArrayColumns arrayColumns = SqlServerDialect.INSTANCE.getArraySupport();
+
+		assertThat(arrayColumns.isSupported()).isFalse();
+		assertThatThrownBy(() -> arrayColumns.getArrayType(String.class)).isInstanceOf(UnsupportedOperationException.class);
+	}
 }

--- a/src/test/java/org/springframework/data/r2dbc/function/DefaultReactiveDataAccessStrategyUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/function/DefaultReactiveDataAccessStrategyUnitTests.java
@@ -8,9 +8,12 @@ import io.r2dbc.spi.Statement;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
 import org.springframework.data.r2dbc.dialect.PostgresDialect;
+import org.springframework.data.r2dbc.function.convert.SettableValue;
 
 /**
  * Unit tests for {@link DefaultReactiveDataAccessStrategy}.
@@ -100,5 +103,39 @@ public class DefaultReactiveDataAccessStrategyUnitTests {
 
 		operation.bindId(statement, "bar");
 		assertThat(operation.toQuery()).isEqualTo("DELETE FROM table WHERE id IN ($1, $2)");
+	}
+
+	@Test // gh-22
+	public void shouldUpdateArray() {
+
+		Map<String, SettableValue> columnsToUpdate = strategy
+				.getColumnsToUpdate(new WithCollectionTypes(new String[] { "one", "two" }, null));
+
+		Object stringArray = columnsToUpdate.get("string_array").getValue();
+		assertThat(stringArray).isInstanceOf(String[].class);
+		assertThat((String[]) stringArray).hasSize(2).contains("one", "two");
+	}
+
+	@Test // gh-22
+	public void shouldConvertListToArray() {
+
+		Map<String, SettableValue> columnsToUpdate = strategy
+				.getColumnsToUpdate(new WithCollectionTypes(null, Arrays.asList("one", "two")));
+
+		Object stringArray = columnsToUpdate.get("string_collection").getValue();
+		assertThat(stringArray).isInstanceOf(String[].class);
+		assertThat((String[]) stringArray).hasSize(2).contains("one", "two");
+	}
+
+	static class WithCollectionTypes {
+
+		String[] stringArray;
+
+		List<String> stringCollection;
+
+		WithCollectionTypes(String[] stringArray, List<String> stringCollection) {
+			this.stringArray = stringArray;
+			this.stringCollection = stringCollection;
+		}
 	}
 }

--- a/src/test/java/org/springframework/data/r2dbc/function/DefaultReactiveDataAccessStrategyUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/function/DefaultReactiveDataAccessStrategyUnitTests.java
@@ -112,6 +112,7 @@ public class DefaultReactiveDataAccessStrategyUnitTests {
 				.getColumnsToUpdate(new WithCollectionTypes(new String[] { "one", "two" }, null));
 
 		Object stringArray = columnsToUpdate.get("string_array").getValue();
+
 		assertThat(stringArray).isInstanceOf(String[].class);
 		assertThat((String[]) stringArray).hasSize(2).contains("one", "two");
 	}
@@ -123,6 +124,7 @@ public class DefaultReactiveDataAccessStrategyUnitTests {
 				.getColumnsToUpdate(new WithCollectionTypes(null, Arrays.asList("one", "two")));
 
 		Object stringArray = columnsToUpdate.get("string_collection").getValue();
+
 		assertThat(stringArray).isInstanceOf(String[].class);
 		assertThat((String[]) stringArray).hasSize(2).contains("one", "two");
 	}
@@ -134,6 +136,7 @@ public class DefaultReactiveDataAccessStrategyUnitTests {
 		List<String> stringCollection;
 
 		WithCollectionTypes(String[] stringArray, List<String> stringCollection) {
+
 			this.stringArray = stringArray;
 			this.stringCollection = stringCollection;
 		}

--- a/src/test/java/org/springframework/data/r2dbc/function/PostgresIntegrationTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/function/PostgresIntegrationTests.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.function;
+
+import static org.assertj.core.api.Assertions.*;
+
+import io.r2dbc.spi.ConnectionFactory;
+import lombok.AllArgsConstructor;
+import reactor.test.StepVerifier;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.sql.DataSource;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.springframework.data.r2dbc.testing.ExternalDatabase;
+import org.springframework.data.r2dbc.testing.PostgresTestSupport;
+import org.springframework.data.r2dbc.testing.R2dbcIntegrationTestSupport;
+import org.springframework.data.relational.core.mapping.Table;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Integration tests for PostgreSQL-specific features such as array support.
+ *
+ * @author Mark Paluch
+ */
+public class PostgresIntegrationTests extends R2dbcIntegrationTestSupport {
+
+	@ClassRule public static final ExternalDatabase database = PostgresTestSupport.database();
+
+	DataSource dataSource = PostgresTestSupport.createDataSource(database);
+	ConnectionFactory connectionFactory = PostgresTestSupport.createConnectionFactory(database);
+	JdbcTemplate template = createJdbcTemplate(dataSource);
+	DatabaseClient client = DatabaseClient.create(connectionFactory);
+
+	@Before
+	public void before() {
+
+		template.execute("DROP TABLE IF EXISTS with_arrays");
+		template.execute("CREATE TABLE with_arrays (" //
+				+ "boxed_array INT[]," //
+				+ "primitive_array INT[]," //
+				+ "multidimensional_array INT[]," //
+				+ "collection_array INT[][])");
+	}
+
+	@Test // gh-30
+	@Ignore("https://github.com/r2dbc/r2dbc-postgresql/issues/40, r2dbc-postgresql returns Object[] instead of Integer[]")
+	public void shouldReadAndWritePrimitiveSingleDimensionArrays() {
+
+		EntityWithArrays withArrays = new EntityWithArrays(null, new int[] { 1, 2, 3 }, null, null);
+
+		insert(withArrays);
+		selectAndAssert(actual -> {
+			assertThat(actual.primitiveArray).containsExactly(1, 2, 3);
+		});
+	}
+
+	@Test // gh-30
+	public void shouldReadAndWriteBoxedSingleDimensionArrays() {
+
+		EntityWithArrays withArrays = new EntityWithArrays(new Integer[] { 1, 2, 3 }, null, null, null);
+
+		insert(withArrays);
+
+		selectAndAssert(actual -> {
+
+			assertThat(actual.boxedArray).containsExactly(1, 2, 3);
+
+		});
+	}
+
+	@Test // gh-30
+	public void shouldReadAndWriteConvertedDimensionArrays() {
+
+		EntityWithArrays withArrays = new EntityWithArrays(null, null, null, Arrays.asList(5, 6, 7));
+
+		insert(withArrays);
+
+		selectAndAssert(actual -> {
+			assertThat(actual.collectionArray).containsExactly(5, 6, 7);
+		});
+	}
+
+	@Test // gh-30
+	@Ignore("https://github.com/r2dbc/r2dbc-postgresql/issues/42, Multi-dimensional arrays not supported yet")
+	public void shouldReadAndWriteMultiDimensionArrays() {
+
+		EntityWithArrays withArrays = new EntityWithArrays(null, null, new int[][] { { 1, 2, 3 }, { 4, 5 } }, null);
+
+		insert(withArrays);
+
+		selectAndAssert(actual -> {
+
+			assertThat(actual.multidimensionalArray).hasSize(2);
+			assertThat(actual.multidimensionalArray[0]).containsExactly(1, 2, 3);
+			assertThat(actual.multidimensionalArray[1]).containsExactly(4, 5, 6);
+		});
+	}
+
+	private void insert(EntityWithArrays object) {
+
+		client.insert() //
+				.into(EntityWithArrays.class) //
+				.using(object) //
+				.then() //
+				.as(StepVerifier::create) //
+				.verifyComplete();
+	}
+
+	private void selectAndAssert(Consumer<? super EntityWithArrays> assertion) {
+
+		client.select() //
+				.from(EntityWithArrays.class).fetch() //
+				.first() //
+				.as(StepVerifier::create) //
+				.consumeNextWith(assertion).verifyComplete();
+	}
+
+	@Table("with_arrays")
+	@AllArgsConstructor
+	static class EntityWithArrays {
+
+		Integer[] boxedArray;
+		int[] primitiveArray;
+		int[][] multidimensionalArray;
+		List<Integer> collectionArray;
+	}
+}

--- a/src/test/java/org/springframework/data/r2dbc/function/convert/EntityRowMapperUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/function/convert/EntityRowMapperUnitTests.java
@@ -8,6 +8,7 @@ import io.r2dbc.spi.RowMetadata;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,6 +21,7 @@ import org.springframework.data.relational.core.mapping.RelationalPersistentEnti
  * Unit tests for {@link EntityRowMapper}.
  *
  * @author Mark Paluch
+ * @author Jens Schauder
  */
 @RunWith(MockitoJUnitRunner.class)
 public class EntityRowMapperUnitTests {
@@ -73,7 +75,7 @@ public class EntityRowMapperUnitTests {
 	public void shouldConvertArrayToSet() {
 
 		EntityRowMapper<EntityWithCollection> mapper = getRowMapper(EntityWithCollection.class);
-		when(rowMock.get("integerSet")).thenReturn((new int[] { 3, 14 }));
+		when(rowMock.get("integer_set")).thenReturn((new int[] { 3, 14 }));
 
 		EntityWithCollection result = mapper.apply(rowMock, metadata);
 		assertThat(result.integerSet).contains(3, 14);
@@ -83,7 +85,7 @@ public class EntityRowMapperUnitTests {
 	public void shouldConvertArrayMembers() {
 
 		EntityRowMapper<EntityWithCollection> mapper = getRowMapper(EntityWithCollection.class);
-		when(rowMock.get("primitiveIntegers")).thenReturn((new long[] { 3L, 14L }));
+		when(rowMock.get("primitive_integers")).thenReturn((new Long[] { 3L, 14L }));
 
 		EntityWithCollection result = mapper.apply(rowMock, metadata);
 		assertThat(result.primitiveIntegers).contains(3, 14);
@@ -93,11 +95,12 @@ public class EntityRowMapperUnitTests {
 	public void shouldConvertArrayToBoxedArray() {
 
 		EntityRowMapper<EntityWithCollection> mapper = getRowMapper(EntityWithCollection.class);
-		when(rowMock.get("boxedIntegers")).thenReturn((new int[] { 3, 11 }));
+		when(rowMock.get("boxed_integers")).thenReturn((new int[] { 3, 11 }));
 
 		EntityWithCollection result = mapper.apply(rowMock, metadata);
 		assertThat(result.boxedIntegers).contains(3, 11);
 	}
+
 	@SuppressWarnings("unchecked")
 	private <T> EntityRowMapper<T> getRowMapper(Class<T> type) {
 		RelationalPersistentEntity<T> entity = (RelationalPersistentEntity<T>) strategy.getMappingContext()

--- a/src/test/java/org/springframework/data/r2dbc/function/convert/EntityRowMapperUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/function/convert/EntityRowMapperUnitTests.java
@@ -7,6 +7,8 @@ import io.r2dbc.spi.Row;
 import io.r2dbc.spi.RowMetadata;
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -57,6 +59,17 @@ public class EntityRowMapperUnitTests {
 		assertThat(result.id).isEqualTo(36L);
 	}
 
+	@Test // gh-30
+	public void shouldConvertArrayToCollection() {
+
+		EntityRowMapper<EntityWithCollection> mapper = getRowMapper(EntityWithCollection.class);
+		when(rowMock.get("ids")).thenReturn((new String[] { "foo", "bar" }));
+
+		EntityWithCollection result = mapper.apply(rowMock, metadata);
+		assertThat(result.ids).contains("foo", "bar");
+	}
+
+	@SuppressWarnings("unchecked")
 	private <T> EntityRowMapper<T> getRowMapper(Class<T> type) {
 		RelationalPersistentEntity<T> entity = (RelationalPersistentEntity<T>) strategy.getMappingContext()
 				.getRequiredPersistentEntity(type);
@@ -75,5 +88,9 @@ public class EntityRowMapperUnitTests {
 	@RequiredArgsConstructor
 	static class ConversionWithConstructorCreation {
 		final long id;
+	}
+
+	static class EntityWithCollection {
+		List<String> ids;
 	}
 }

--- a/src/test/java/org/springframework/data/r2dbc/function/convert/EntityRowMapperUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/function/convert/EntityRowMapperUnitTests.java
@@ -1,0 +1,79 @@
+package org.springframework.data.r2dbc.function.convert;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.r2dbc.spi.Row;
+import io.r2dbc.spi.RowMetadata;
+import lombok.RequiredArgsConstructor;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.data.r2dbc.dialect.PostgresDialect;
+import org.springframework.data.r2dbc.function.DefaultReactiveDataAccessStrategy;
+import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
+
+/**
+ * Unit tests for {@link EntityRowMapper}.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class EntityRowMapperUnitTests {
+
+	DefaultReactiveDataAccessStrategy strategy = new DefaultReactiveDataAccessStrategy(PostgresDialect.INSTANCE);
+
+	Row rowMock = mock(Row.class);
+	RowMetadata metadata = mock(RowMetadata.class);
+
+	@Test // gh-22
+	public void shouldMapSimpleEntity() {
+
+		EntityRowMapper<SimpleEntity> mapper = getRowMapper(SimpleEntity.class);
+		when(rowMock.get("id")).thenReturn("foo");
+
+		SimpleEntity result = mapper.apply(rowMock, metadata);
+		assertThat(result.id).isEqualTo("foo");
+	}
+
+	@Test // gh-22
+	public void shouldMapSimpleEntityWithConstructorCreation() {
+
+		EntityRowMapper<SimpleEntityConstructorCreation> mapper = getRowMapper(SimpleEntityConstructorCreation.class);
+		when(rowMock.get("id")).thenReturn("foo");
+
+		SimpleEntityConstructorCreation result = mapper.apply(rowMock, metadata);
+		assertThat(result.id).isEqualTo("foo");
+	}
+
+	@Test // gh-22
+	public void shouldApplyConversionWithConstructorCreation() {
+
+		EntityRowMapper<ConversionWithConstructorCreation> mapper = getRowMapper(ConversionWithConstructorCreation.class);
+		when(rowMock.get("id")).thenReturn((byte) 0x24);
+
+		ConversionWithConstructorCreation result = mapper.apply(rowMock, metadata);
+		assertThat(result.id).isEqualTo(36L);
+	}
+
+	private <T> EntityRowMapper<T> getRowMapper(Class<T> type) {
+		RelationalPersistentEntity<T> entity = (RelationalPersistentEntity<T>) strategy.getMappingContext()
+				.getRequiredPersistentEntity(type);
+		return new EntityRowMapper<>(entity, strategy.getRelationalConverter());
+	}
+
+	static class SimpleEntity {
+		String id;
+	}
+
+	@RequiredArgsConstructor
+	static class SimpleEntityConstructorCreation {
+		final String id;
+	}
+
+	@RequiredArgsConstructor
+	static class ConversionWithConstructorCreation {
+		final long id;
+	}
+}

--- a/src/test/java/org/springframework/data/r2dbc/function/convert/EntityRowMapperUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/function/convert/EntityRowMapperUnitTests.java
@@ -69,6 +69,35 @@ public class EntityRowMapperUnitTests {
 		assertThat(result.ids).contains("foo", "bar");
 	}
 
+	@Test // gh-30
+	public void shouldConvertArrayToSet() {
+
+		EntityRowMapper<EntityWithCollection> mapper = getRowMapper(EntityWithCollection.class);
+		when(rowMock.get("integerSet")).thenReturn((new int[] { 3, 14 }));
+
+		EntityWithCollection result = mapper.apply(rowMock, metadata);
+		assertThat(result.integerSet).contains(3, 14);
+	}
+
+	@Test // gh-30
+	public void shouldConvertArrayMembers() {
+
+		EntityRowMapper<EntityWithCollection> mapper = getRowMapper(EntityWithCollection.class);
+		when(rowMock.get("primitiveIntegers")).thenReturn((new long[] { 3L, 14L }));
+
+		EntityWithCollection result = mapper.apply(rowMock, metadata);
+		assertThat(result.primitiveIntegers).contains(3, 14);
+	}
+
+	@Test // gh-30
+	public void shouldConvertArrayToBoxedArray() {
+
+		EntityRowMapper<EntityWithCollection> mapper = getRowMapper(EntityWithCollection.class);
+		when(rowMock.get("boxedIntegers")).thenReturn((new int[] { 3, 11 }));
+
+		EntityWithCollection result = mapper.apply(rowMock, metadata);
+		assertThat(result.boxedIntegers).contains(3, 11);
+	}
 	@SuppressWarnings("unchecked")
 	private <T> EntityRowMapper<T> getRowMapper(Class<T> type) {
 		RelationalPersistentEntity<T> entity = (RelationalPersistentEntity<T>) strategy.getMappingContext()
@@ -92,5 +121,8 @@ public class EntityRowMapperUnitTests {
 
 	static class EntityWithCollection {
 		List<String> ids;
+		Set<Integer> integerSet;
+		Integer[] boxedIntegers;
+		int[] primitiveIntegers;
 	}
 }


### PR DESCRIPTION
We now support custom conversions via R2dbcCustomConversions. Custom conversions introduces simple types that depend on the used dialect. Custom conversions and simple types are held in RelationalConverter and MappingContext.

Simple types and conversions are used by DatabaseClient and repository support to properly apply registered converters and support native types such as array-columns.

---
Supersedes PR #22.
Related tickets: #22, #26, #30.