### PR TITLE
#8 - Replace exchange() operator with map(…) and then() operators.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,7 +8,7 @@ The state of R2DBC is incubating to evaluate how an reactive integration could l
 
 == This is NOT an ORM
 
-Spring Data R2DBC does not try to be an ORM. 
+Spring Data R2DBC does not try to be an ORM.
 Instead it is more of a construction kit for your personal reactive relational data access component that you can define the way you like or need it.
 
 == Maven Coordinates
@@ -64,12 +64,13 @@ Mono<Integer> count = databaseClient.execute()
 
 Flux<Map<String, Object>> rows = databaseClient.execute()
 				.sql("SELECT id, name, manual FROM legoset")
-				.fetch().all();
+				.fetch()
+				.all();
 
 Flux<Long> result = db.execute()
 				.sql("SELECT txid_current();")
-				.exchange()
-				.flatMapMany(it -> it.extract((r, md) -> r.get(0, Long.class)).all());
+				.map((r, md) -> r.get(0, Long.class))
+				.all();
 ----
 
 === Examples selecting data
@@ -100,14 +101,13 @@ Flux<Integer> ids = databaseClient.insert()
 				.value("id", 42055)
 				.value("name", "Description")
 				.nullValue("manual", Integer.class)
-				.exchange() //
-				.flatMapMany(it -> it.extract((r, m) -> r.get("id", Integer.class)).all())
+				.map((r, m) -> r.get("id", Integer.class)
+				.all();
 
-Flux<Integer> ids = databaseClient.insert()
+Mono<Void> completion = databaseClient.insert()
 				.into(LegoSet.class)
 				.using(legoSet)
-				.exchange()
-				.flatMapMany(it -> it.extract((r, m) -> r.get("id", Integer.class)).all())
+				.then();
 ----
 
 === Examples using reactive repositories
@@ -162,7 +162,7 @@ Flux<Integer> rowsUpdated = databaseClient.inTransaction(db -> {
 [source,java]
 ----
 Flux<Long> txId = databaseClient.execute().sql("SELECT txid_current();").exchange()
-				.flatMapMany(it -> it.extract((r, md) -> r.get(0, Long.class)).all());
+				.flatMapMany(it -> it.map((r, md) -> r.get(0, Long.class)).all());
 
 Mono<Void> then = databaseClient.enableTransactionSynchronization(databaseClient.beginTransaction() //
 				.thenMany(txId)) //

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<version>1.0.0.gh-8-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC.</description>

--- a/src/main/java/org/springframework/data/r2dbc/InvalidResultAccessException.java
+++ b/src/main/java/org/springframework/data/r2dbc/InvalidResultAccessException.java
@@ -25,7 +25,8 @@ import org.springframework.lang.Nullable;
  * Exception thrown when a {@link io.r2dbc.spi.Result} has been accessed in an invalid fashion. Such exceptions always
  * have a {@link io.r2dbc.spi.R2dbcException} root cause.
  * <p>
- * This typically happens when an invalid {@link org.springframework.data.r2dbc.function.SqlResult} column index or name has been specified.
+ * This typically happens when an invalid {@link org.springframework.data.r2dbc.function.FetchSpec} column index or name
+ * has been specified.
  *
  * @author Mark Paluch
  * @see BadSqlGrammarException

--- a/src/main/java/org/springframework/data/r2dbc/function/DatabaseClient.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/DatabaseClient.java
@@ -65,8 +65,9 @@ public interface DatabaseClient {
 
 	/**
 	 * Creates a {@code DatabaseClient} that will use the provided {@link io.r2dbc.spi.ConnectionFactory}.
+	 *
 	 * @param factory The {@code ConnectionFactory} to use for obtaining connections.
-	 * @return a new {@code DatabaseClient}. Guaranteed to be not {@code null}.
+	 * @return a new {@code DatabaseClient}. Guaranteed to be not {@literal null}.
 	 */
 	static DatabaseClient create(ConnectionFactory factory) {
 		return new DefaultDatabaseClientBuilder().connectionFactory(factory).build();
@@ -163,7 +164,7 @@ public interface DatabaseClient {
 		 *
 		 * @param mappingFunction must not be {@literal null}.
 		 * @param <R> result type.
-		 * @return a {@link FetchSpec} for configuration what to fetch. Guaranteed to be not {@code null}.
+		 * @return a {@link FetchSpec} for configuration what to fetch. Guaranteed to be not {@literal null}.
 		 */
 		<R> FetchSpec<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);
 
@@ -199,7 +200,7 @@ public interface DatabaseClient {
 		 *
 		 * @param mappingFunction must not be {@literal null}.
 		 * @param <R> result type.
-		 * @return a {@link FetchSpec} for configuration what to fetch. Guaranteed to be not {@code null}.
+		 * @return a {@link FetchSpec} for configuration what to fetch. Guaranteed to be not {@literal null}.
 		 */
 		<R> FetchSpec<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);
 
@@ -225,7 +226,8 @@ public interface DatabaseClient {
 		 * Specify the source {@literal table} to select from.
 		 *
 		 * @param table must not be {@literal null} or empty.
-		 * @return a {@link GenericSelectSpec} for further configuration of the select. Guaranteed to be not {@code null}.
+		 * @return a {@link GenericSelectSpec} for further configuration of the select. Guaranteed to be not
+		 *         {@literal null}.
 		 */
 		GenericSelectSpec from(String table);
 
@@ -233,7 +235,7 @@ public interface DatabaseClient {
 		 * Specify the source table to select from to using the {@link Class entity class}.
 		 *
 		 * @param table must not be {@literal null}.
-		 * @return a {@link TypedSelectSpec} for further configuration of the select. Guaranteed to be not {@code null}.
+		 * @return a {@link TypedSelectSpec} for further configuration of the select. Guaranteed to be not {@literal null}.
 		 */
 		<T> TypedSelectSpec<T> from(Class<T> table);
 	}
@@ -247,7 +249,8 @@ public interface DatabaseClient {
 		 * Specify the target {@literal table} to insert into.
 		 *
 		 * @param table must not be {@literal null} or empty.
-		 * @return a {@link GenericInsertSpec} for further configuration of the insert. Guaranteed to be not {@code null}.
+		 * @return a {@link GenericInsertSpec} for further configuration of the insert. Guaranteed to be not
+		 *         {@literal null}.
 		 */
 		GenericInsertSpec<Map<String, Object>> into(String table);
 
@@ -255,7 +258,7 @@ public interface DatabaseClient {
 		 * Specify the target table to insert to using the {@link Class entity class}.
 		 *
 		 * @param table must not be {@literal null}.
-		 * @return a {@link TypedInsertSpec} for further configuration of the insert. Guaranteed to be not {@code null}.
+		 * @return a {@link TypedInsertSpec} for further configuration of the insert. Guaranteed to be not {@literal null}.
 		 */
 		<T> TypedInsertSpec<T> into(Class<T> table);
 	}
@@ -279,7 +282,7 @@ public interface DatabaseClient {
 		 *
 		 * @param mappingFunction must not be {@literal null}.
 		 * @param <R> result type.
-		 * @return a {@link FetchSpec} for configuration what to fetch. Guaranteed to be not {@code null}.
+		 * @return a {@link FetchSpec} for configuration what to fetch. Guaranteed to be not {@literal null}.
 		 */
 		<R> FetchSpec<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);
 
@@ -308,7 +311,7 @@ public interface DatabaseClient {
 		 *
 		 * @param mappingFunction must not be {@literal null}.
 		 * @param <R> result type.
-		 * @return a {@link FetchSpec} for configuration what to fetch. Guaranteed to be not {@code null}.
+		 * @return a {@link FetchSpec} for configuration what to fetch. Guaranteed to be not {@literal null}.
 		 */
 		<R> FetchSpec<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);
 
@@ -377,8 +380,9 @@ public interface DatabaseClient {
 		/**
 		 * Insert the given {@code objectToInsert}.
 		 *
-		 * @param objectToInsert the object of which the attributes will provide the values for the insert. Must not be {@code null}.
-		 * @return a {@link InsertSpec} for further configuration of the insert. Guaranteed to be not {@code null}.
+		 * @param objectToInsert the object of which the attributes will provide the values for the insert. Must not be
+		 *          {@literal null}.
+		 * @return a {@link InsertSpec} for further configuration of the insert. Guaranteed to be not {@literal null}.
 		 */
 		InsertSpec<Map<String, Object>> using(T objectToInsert);
 
@@ -386,7 +390,7 @@ public interface DatabaseClient {
 		 * Use the given {@code tableName} as insert target.
 		 *
 		 * @param tableName must not be {@literal null} or empty.
-		 * @return a {@link TypedInsertSpec} for further configuration of the insert. Guaranteed to be not {@code null}.
+		 * @return a {@link TypedInsertSpec} for further configuration of the insert. Guaranteed to be not {@literal null}.
 		 */
 		TypedInsertSpec<T> table(String tableName);
 
@@ -394,8 +398,9 @@ public interface DatabaseClient {
 		 * Insert the given {@link Publisher} to insert one or more objects. Inserts only a single object when calling
 		 * {@link FetchSpec#one()} or {@link FetchSpec#first()}.
 		 *
-		 * @param objectToInsert a publisher providing the objects of which the attributes will provide the values for the insert. Must not be {@code null}.
-		 * @return a {@link InsertSpec} for further configuration of the insert. Guaranteed to be not {@code null}.
+		 * @param objectToInsert a publisher providing the objects of which the attributes will provide the values for the
+		 *          insert. Must not be {@literal null}.
+		 * @return a {@link InsertSpec} for further configuration of the insert. Guaranteed to be not {@literal null}.
 		 * @see InsertSpec#fetch()
 		 */
 		InsertSpec<Map<String, Object>> using(Publisher<T> objectToInsert);
@@ -413,7 +418,7 @@ public interface DatabaseClient {
 		 *
 		 * @param mappingFunction must not be {@literal null}.
 		 * @param <R> result type.
-		 * @return a {@link FetchSpec} for configuration what to fetch. Guaranteed to be not {@code null}.
+		 * @return a {@link FetchSpec} for configuration what to fetch. Guaranteed to be not {@literal null}.
 		 */
 		<R> FetchSpec<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);
 

--- a/src/main/java/org/springframework/data/r2dbc/function/DatabaseClient.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/DatabaseClient.java
@@ -166,7 +166,7 @@ public interface DatabaseClient {
 		 * @param <R> result type.
 		 * @return a {@link FetchSpec} for configuration what to fetch. Guaranteed to be not {@literal null}.
 		 */
-		<R> FetchSpec<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);
+		<R> RowsFetchSpec<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);
 
 		/**
 		 * Perform the SQL call and retrieve the result.
@@ -202,7 +202,7 @@ public interface DatabaseClient {
 		 * @param <R> result type.
 		 * @return a {@link FetchSpec} for configuration what to fetch. Guaranteed to be not {@literal null}.
 		 */
-		<R> FetchSpec<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);
+		<R> RowsFetchSpec<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);
 
 		/**
 		 * Perform the SQL call and retrieve the result.
@@ -284,7 +284,7 @@ public interface DatabaseClient {
 		 * @param <R> result type.
 		 * @return a {@link FetchSpec} for configuration what to fetch. Guaranteed to be not {@literal null}.
 		 */
-		<R> FetchSpec<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);
+		<R> RowsFetchSpec<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);
 
 		/**
 		 * Perform the SQL call and retrieve the result.
@@ -304,7 +304,7 @@ public interface DatabaseClient {
 		 * @param resultType must not be {@literal null}.
 		 * @param <R> result type.
 		 */
-		<R> FetchSpec<R> as(Class<R> resultType);
+		<R> RowsFetchSpec<R> as(Class<R> resultType);
 
 		/**
 		 * Configure a result mapping {@link java.util.function.BiFunction function}.
@@ -313,7 +313,7 @@ public interface DatabaseClient {
 		 * @param <R> result type.
 		 * @return a {@link FetchSpec} for configuration what to fetch. Guaranteed to be not {@literal null}.
 		 */
-		<R> FetchSpec<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);
+		<R> RowsFetchSpec<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);
 
 		/**
 		 * Perform the SQL call and retrieve the result.
@@ -416,11 +416,11 @@ public interface DatabaseClient {
 		/**
 		 * Configure a result mapping {@link java.util.function.BiFunction function}.
 		 *
-		 * @param mappingFunction must not be {@literal null}.
+		 * @param mappwingFunction must not be {@literal null}.
 		 * @param <R> result type.
 		 * @return a {@link FetchSpec} for configuration what to fetch. Guaranteed to be not {@literal null}.
 		 */
-		<R> FetchSpec<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);
+		<R> RowsFetchSpec<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);
 
 		/**
 		 * Perform the SQL call and retrieve the result.

--- a/src/main/java/org/springframework/data/r2dbc/function/DatabaseClient.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/DatabaseClient.java
@@ -64,7 +64,9 @@ public interface DatabaseClient {
 	// Static, factory methods
 
 	/**
-	 * A variant of {@link #create()} that accepts a {@link io.r2dbc.spi.ConnectionFactory}
+	 * Creates a {@code DatabaseClient} that will use the provided {@link io.r2dbc.spi.ConnectionFactory}.
+	 * @param factory The {@code ConnectionFactory} to use for obtaining connections.
+	 * @return a new {@code DatabaseClient}. Guaranteed to be not {@code null}.
 	 */
 	static DatabaseClient create(ConnectionFactory factory) {
 		return new DefaultDatabaseClientBuilder().connectionFactory(factory).build();
@@ -161,7 +163,7 @@ public interface DatabaseClient {
 		 *
 		 * @param mappingFunction must not be {@literal null}.
 		 * @param <R> result type.
-		 * @return
+		 * @return a {@link FetchSpec} for configuration what to fetch. Guaranteed to be not {@code null}.
 		 */
 		<R> FetchSpec<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);
 
@@ -197,7 +199,7 @@ public interface DatabaseClient {
 		 *
 		 * @param mappingFunction must not be {@literal null}.
 		 * @param <R> result type.
-		 * @return
+		 * @return a {@link FetchSpec} for configuration what to fetch. Guaranteed to be not {@code null}.
 		 */
 		<R> FetchSpec<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);
 
@@ -223,7 +225,7 @@ public interface DatabaseClient {
 		 * Specify the source {@literal table} to select from.
 		 *
 		 * @param table must not be {@literal null} or empty.
-		 * @return
+		 * @return a {@link GenericSelectSpec} for further configuration of the select. Guaranteed to be not {@code null}.
 		 */
 		GenericSelectSpec from(String table);
 
@@ -231,7 +233,7 @@ public interface DatabaseClient {
 		 * Specify the source table to select from to using the {@link Class entity class}.
 		 *
 		 * @param table must not be {@literal null}.
-		 * @return
+		 * @return a {@link TypedSelectSpec} for further configuration of the select. Guaranteed to be not {@code null}.
 		 */
 		<T> TypedSelectSpec<T> from(Class<T> table);
 	}
@@ -245,7 +247,7 @@ public interface DatabaseClient {
 		 * Specify the target {@literal table} to insert into.
 		 *
 		 * @param table must not be {@literal null} or empty.
-		 * @return
+		 * @return a {@link GenericInsertSpec} for further configuration of the insert. Guaranteed to be not {@code null}.
 		 */
 		GenericInsertSpec<Map<String, Object>> into(String table);
 
@@ -253,7 +255,7 @@ public interface DatabaseClient {
 		 * Specify the target table to insert to using the {@link Class entity class}.
 		 *
 		 * @param table must not be {@literal null}.
-		 * @return
+		 * @return a {@link TypedInsertSpec} for further configuration of the insert. Guaranteed to be not {@code null}.
 		 */
 		<T> TypedInsertSpec<T> into(Class<T> table);
 	}
@@ -277,7 +279,7 @@ public interface DatabaseClient {
 		 *
 		 * @param mappingFunction must not be {@literal null}.
 		 * @param <R> result type.
-		 * @return
+		 * @return a {@link FetchSpec} for configuration what to fetch. Guaranteed to be not {@code null}.
 		 */
 		<R> FetchSpec<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);
 
@@ -306,7 +308,7 @@ public interface DatabaseClient {
 		 *
 		 * @param mappingFunction must not be {@literal null}.
 		 * @param <R> result type.
-		 * @return
+		 * @return a {@link FetchSpec} for configuration what to fetch. Guaranteed to be not {@code null}.
 		 */
 		<R> FetchSpec<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);
 
@@ -375,8 +377,8 @@ public interface DatabaseClient {
 		/**
 		 * Insert the given {@code objectToInsert}.
 		 *
-		 * @param objectToInsert
-		 * @return
+		 * @param objectToInsert the object of which the attributes will provide the values for the insert. Must not be {@code null}.
+		 * @return a {@link InsertSpec} for further configuration of the insert. Guaranteed to be not {@code null}.
 		 */
 		InsertSpec<Map<String, Object>> using(T objectToInsert);
 
@@ -384,7 +386,7 @@ public interface DatabaseClient {
 		 * Use the given {@code tableName} as insert target.
 		 *
 		 * @param tableName must not be {@literal null} or empty.
-		 * @return
+		 * @return a {@link TypedInsertSpec} for further configuration of the insert. Guaranteed to be not {@code null}.
 		 */
 		TypedInsertSpec<T> table(String tableName);
 
@@ -392,8 +394,8 @@ public interface DatabaseClient {
 		 * Insert the given {@link Publisher} to insert one or more objects. Inserts only a single object when calling
 		 * {@link FetchSpec#one()} or {@link FetchSpec#first()}.
 		 *
-		 * @param objectToInsert
-		 * @return
+		 * @param objectToInsert a publisher providing the objects of which the attributes will provide the values for the insert. Must not be {@code null}.
+		 * @return a {@link InsertSpec} for further configuration of the insert. Guaranteed to be not {@code null}.
 		 * @see InsertSpec#fetch()
 		 */
 		InsertSpec<Map<String, Object>> using(Publisher<T> objectToInsert);
@@ -411,7 +413,7 @@ public interface DatabaseClient {
 		 *
 		 * @param mappingFunction must not be {@literal null}.
 		 * @param <R> result type.
-		 * @return
+		 * @return a {@link FetchSpec} for configuration what to fetch. Guaranteed to be not {@code null}.
 		 */
 		<R> FetchSpec<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);
 
@@ -436,15 +438,15 @@ public interface DatabaseClient {
 		/**
 		 * Bind a non-{@literal null} value to a parameter identified by its {@code index}.
 		 *
-		 * @param index
-		 * @param value must not be {@literal null}.
+		 * @param index zero based index to bind the parameter to.
+		 * @param value to bind. Must not be {@literal null}.
 		 */
 		S bind(int index, Object value);
 
 		/**
 		 * Bind a {@literal null} value to a parameter identified by its {@code index}.
 		 *
-		 * @param index
+		 * @param index zero based index to bind the parameter to.
 		 * @param type must not be {@literal null}.
 		 */
 		S bindNull(int index, Class<?> type);

--- a/src/main/java/org/springframework/data/r2dbc/function/DefaultDatabaseClient.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/DefaultDatabaseClient.java
@@ -23,20 +23,6 @@ import io.r2dbc.spi.Row;
 import io.r2dbc.spi.RowMetadata;
 import io.r2dbc.spi.Statement;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.reactivestreams.Publisher;
-import org.springframework.dao.DataAccessException;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.r2dbc.UncategorizedR2dbcException;
-import org.springframework.data.r2dbc.function.connectionfactory.ConnectionProxy;
-import org.springframework.data.r2dbc.function.convert.ColumnMapRowMapper;
-import org.springframework.data.r2dbc.function.convert.SettableValue;
-import org.springframework.data.r2dbc.support.R2dbcExceptionTranslator;
-import org.springframework.jdbc.core.SqlProvider;
-import org.springframework.lang.Nullable;
-import org.springframework.util.Assert;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -56,6 +42,21 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.reactivestreams.Publisher;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.r2dbc.UncategorizedR2dbcException;
+import org.springframework.data.r2dbc.function.connectionfactory.ConnectionProxy;
+import org.springframework.data.r2dbc.function.convert.ColumnMapRowMapper;
+import org.springframework.data.r2dbc.function.convert.SettableValue;
+import org.springframework.data.r2dbc.support.R2dbcExceptionTranslator;
+import org.springframework.jdbc.core.SqlProvider;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 
 /**
  * Default implementation of {@link DatabaseClient}.
@@ -313,7 +314,7 @@ class DefaultDatabaseClient implements DatabaseClient, ConnectionAccessor {
 			return sql;
 		}
 
-		<T> SqlResult<T> exchange(String sql, BiFunction<Row, RowMetadata, T> mappingFunction) {
+		<T> FetchSpec<T> exchange(String sql, BiFunction<Row, RowMetadata, T> mappingFunction) {
 
 			Function<Connection, Statement<?>> executeFunction = it -> {
 
@@ -603,7 +604,7 @@ class DefaultDatabaseClient implements DatabaseClient, ConnectionAccessor {
 			return createInstance(table, projectedFields, sort, page);
 		}
 
-		<R> SqlResult<R> execute(String sql, BiFunction<Row, RowMetadata, R> mappingFunction) {
+		<R> FetchSpec<R> execute(String sql, BiFunction<Row, RowMetadata, R> mappingFunction) {
 
 			Function<Connection, Statement<?>> selectFunction = it -> {
 
@@ -674,7 +675,7 @@ class DefaultDatabaseClient implements DatabaseClient, ConnectionAccessor {
 			return exchange(ColumnMapRowMapper.INSTANCE);
 		}
 
-		private <R> SqlResult<R> exchange(BiFunction<Row, RowMetadata, R> mappingFunction) {
+		private <R> FetchSpec<R> exchange(BiFunction<Row, RowMetadata, R> mappingFunction) {
 
 			Set<String> columns;
 
@@ -758,11 +759,11 @@ class DefaultDatabaseClient implements DatabaseClient, ConnectionAccessor {
 		}
 
 		@Override
-		public SqlResult<T> fetch() {
+		public FetchSpec<T> fetch() {
 			return exchange(mappingFunction);
 		}
 
-		private <R> SqlResult<R> exchange(BiFunction<Row, RowMetadata, R> mappingFunction) {
+		private <R> FetchSpec<R> exchange(BiFunction<Row, RowMetadata, R> mappingFunction) {
 
 			List<String> columns;
 
@@ -851,7 +852,7 @@ class DefaultDatabaseClient implements DatabaseClient, ConnectionAccessor {
 			return fetch().rowsUpdated().then();
 		}
 
-		private <R> SqlResult<R> exchange(BiFunction<Row, RowMetadata, R> mappingFunction) {
+		private <R> FetchSpec<R> exchange(BiFunction<Row, RowMetadata, R> mappingFunction) {
 
 			if (byName.isEmpty()) {
 				throw new IllegalStateException("Insert fields is empty!");
@@ -970,7 +971,7 @@ class DefaultDatabaseClient implements DatabaseClient, ConnectionAccessor {
 			};
 		}
 
-		private <MR> SqlResult<MR> exchange(Object toInsert, BiFunction<Row, RowMetadata, MR> mappingFunction) {
+		private <MR> FetchSpec<MR> exchange(Object toInsert, BiFunction<Row, RowMetadata, MR> mappingFunction) {
 
 			List<SettableValue> insertValues = dataAccessStrategy.getValuesToInsert(toInsert);
 			Set<String> columns = new LinkedHashSet<>();

--- a/src/main/java/org/springframework/data/r2dbc/function/DefaultSqlResult.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/DefaultSqlResult.java
@@ -101,8 +101,8 @@ class DefaultSqlResult<T> implements SqlResult<T> {
 	/**
 	 * Returns an empty {@link SqlResult}.
 	 *
-	 * @param <R>
-	 * @return
+	 * @param <R> value type of the {@code SqlResult}.
+	 * @return a {@code SqlResult}.
 	 */
 	@SuppressWarnings("unchecked")
 	public static <R> SqlResult<R> empty() {

--- a/src/main/java/org/springframework/data/r2dbc/function/DefaultSqlResult.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/DefaultSqlResult.java
@@ -34,6 +34,33 @@ import org.springframework.jdbc.core.SqlProvider;
  */
 class DefaultSqlResult<T> implements SqlResult<T> {
 
+	private final static SqlResult<?> EMPTY = new SqlResult<Object>() {
+		@Override
+		public <R> SqlResult<R> map(BiFunction<Row, RowMetadata, R> mappingFunction) {
+			return DefaultSqlResult.empty();
+		}
+
+		@Override
+		public Mono<Object> one() {
+			return Mono.empty();
+		}
+
+		@Override
+		public Mono<Object> first() {
+			return Mono.empty();
+		}
+
+		@Override
+		public Flux<Object> all() {
+			return Flux.empty();
+		}
+
+		@Override
+		public Mono<Integer> rowsUpdated() {
+			return Mono.empty();
+		}
+	};
+
 	private final ConnectionAccessor connectionAccessor;
 	private final String sql;
 	private final Function<Connection, Flux<Result>> resultFunction;
@@ -71,11 +98,22 @@ class DefaultSqlResult<T> implements SqlResult<T> {
 		});
 	}
 
+	/**
+	 * Returns an empty {@link SqlResult}.
+	 *
+	 * @param <R>
+	 * @return
+	 */
+	@SuppressWarnings("unchecked")
+	public static <R> SqlResult<R> empty() {
+		return (SqlResult<R>) EMPTY;
+	}
+
 	/* (non-Javadoc)
-	 * @see org.springframework.data.jdbc.core.function.SqlResult#extract(java.util.function.BiFunction)
+	 * @see org.springframework.data.jdbc.core.function.SqlResult#map(java.util.function.BiFunction)
 	 */
 	@Override
-	public <R> SqlResult<R> extract(BiFunction<Row, RowMetadata, R> mappingFunction) {
+	public <R> SqlResult<R> map(BiFunction<Row, RowMetadata, R> mappingFunction) {
 		return new DefaultSqlResult<>(connectionAccessor, sql, resultFunction, updatedRowsFunction, mappingFunction);
 	}
 

--- a/src/main/java/org/springframework/data/r2dbc/function/RowsFetchSpec.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/RowsFetchSpec.java
@@ -15,12 +15,36 @@
  */
 package org.springframework.data.r2dbc.function;
 
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
 /**
- * Contract for fetching results.
+ * Contract for fetching tabular results.
  *
  * @param <T> row result type.
  * @author Mark Paluch
- * @see RowsFetchSpec
- * @see UpdatedRowsFetchSpec
  */
-public interface FetchSpec<T> extends RowsFetchSpec<T>, UpdatedRowsFetchSpec {}
+public interface RowsFetchSpec<T> {
+
+	/**
+	 * Get exactly zero or one result.
+	 *
+	 * @return {@link Mono#empty()} if no match found. Never {@literal null}.
+	 * @throws org.springframework.dao.IncorrectResultSizeDataAccessException if more than one match found.
+	 */
+	Mono<T> one();
+
+	/**
+	 * Get the first or no result.
+	 *
+	 * @return {@link Mono#empty()} if no match found. Never {@literal null}.
+	 */
+	Mono<T> first();
+
+	/**
+	 * Get all matching elements.
+	 *
+	 * @return never {@literal null}.
+	 */
+	Flux<T> all();
+}

--- a/src/main/java/org/springframework/data/r2dbc/function/SqlResult.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/SqlResult.java
@@ -25,7 +25,7 @@ import java.util.function.BiFunction;
  *
  * @author Mark Paluch
  */
-public interface SqlResult<T> extends FetchSpec<T> {
+interface SqlResult<T> extends FetchSpec<T> {
 
 	/**
 	 * Apply a {@link BiFunction mapping function} to the result that emits {@link Row}s.

--- a/src/main/java/org/springframework/data/r2dbc/function/SqlResult.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/SqlResult.java
@@ -31,7 +31,7 @@ public interface SqlResult<T> extends FetchSpec<T> {
 	 * Apply a {@link BiFunction mapping function} to the result that emits {@link Row}s.
 	 *
 	 * @param mappingFunction must not be {@literal null}.
-	 * @param <R>
+	 * @param <R> the value type of the {@code SqlResult}.
 	 * @return a new {@link SqlResult} with {@link BiFunction mapping function} applied.
 	 */
 	<R> SqlResult<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);

--- a/src/main/java/org/springframework/data/r2dbc/function/SqlResult.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/SqlResult.java
@@ -34,5 +34,5 @@ public interface SqlResult<T> extends FetchSpec<T> {
 	 * @param <R>
 	 * @return a new {@link SqlResult} with {@link BiFunction mapping function} applied.
 	 */
-	<R> SqlResult<R> extract(BiFunction<Row, RowMetadata, R> mappingFunction);
+	<R> SqlResult<R> map(BiFunction<Row, RowMetadata, R> mappingFunction);
 }

--- a/src/main/java/org/springframework/data/r2dbc/function/UpdatedRowsFetchSpec.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/UpdatedRowsFetchSpec.java
@@ -15,12 +15,19 @@
  */
 package org.springframework.data.r2dbc.function;
 
+import reactor.core.publisher.Mono;
+
 /**
- * Contract for fetching results.
+ * Contract for fetching the number of affected rows.
  *
- * @param <T> row result type.
  * @author Mark Paluch
- * @see RowsFetchSpec
- * @see UpdatedRowsFetchSpec
  */
-public interface FetchSpec<T> extends RowsFetchSpec<T>, UpdatedRowsFetchSpec {}
+public interface UpdatedRowsFetchSpec {
+
+	/**
+	 * Get the number of updated rows.
+	 *
+	 * @return {@link Mono} emitting the number of updated rows. Never {@literal null}.
+	 */
+	Mono<Integer> rowsUpdated();
+}

--- a/src/main/java/org/springframework/data/r2dbc/repository/support/SimpleR2dbcRepository.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/support/SimpleR2dbcRepository.java
@@ -315,14 +315,16 @@ public class SimpleR2dbcRepository<T, ID> implements ReactiveCrudRepository<T, I
 	}
 
 	private String getIdColumnName() {
-		return converter.getMappingContext().getRequiredPersistentEntity(entity.getJavaType()).getRequiredIdProperty()
+
+		return converter //
+				.getMappingContext() //
+				.getRequiredPersistentEntity(entity.getJavaType()) //
+				.getRequiredIdProperty() //
 				.getColumnName();
 	}
 
 	private BiConsumer<String, SettableValue> bind(BindableOperation operation, Statement<?> statement) {
 
-		return (k, v) -> {
-			operation.bind(statement, v);
-		};
+		return (k, v) -> operation.bind(statement, v);
 	}
 }

--- a/src/test/java/org/springframework/data/r2dbc/function/AbstractDatabaseClientIntegrationTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/function/AbstractDatabaseClientIntegrationTests.java
@@ -15,17 +15,8 @@
  */
 package org.springframework.data.r2dbc.function;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.springframework.data.domain.Sort.Order.*;
-
 import io.r2dbc.spi.ConnectionFactory;
 import lombok.Data;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Hooks;
-import reactor.test.StepVerifier;
-
-import javax.sql.DataSource;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.dao.DataAccessException;
@@ -35,6 +26,14 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.r2dbc.testing.R2dbcIntegrationTestSupport;
 import org.springframework.data.relational.core.mapping.Table;
 import org.springframework.jdbc.core.JdbcTemplate;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Hooks;
+import reactor.test.StepVerifier;
+
+import javax.sql.DataSource;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.data.domain.Sort.Order.*;
 
 /**
  * Integration tests for {@link DatabaseClient}.
@@ -58,7 +57,8 @@ public abstract class AbstractDatabaseClientIntegrationTests extends R2dbcIntegr
 
 		try {
 			jdbc.execute("DROP TABLE legoset");
-		} catch (DataAccessException e) {}
+		} catch (DataAccessException e) {
+		}
 		jdbc.execute(getCreateTableStatement());
 	}
 
@@ -90,12 +90,10 @@ public abstract class AbstractDatabaseClientIntegrationTests extends R2dbcIntegr
 
 	/**
 	 * Get a parameterized {@code INSERT INTO legoset} statement setting id, name, and manual values.
-	 *
-	 * @return
 	 */
 	protected abstract String getInsertIntoLegosetStatement();
 
-	@Test
+	@Test // gh-2
 	public void executeInsert() {
 
 		DatabaseClient databaseClient = DatabaseClient.create(connectionFactory);
@@ -115,7 +113,7 @@ public abstract class AbstractDatabaseClientIntegrationTests extends R2dbcIntegr
 		assertThat(jdbc.queryForMap("SELECT id, name, manual FROM legoset")).containsEntry("id", 42055);
 	}
 
-	@Test
+	@Test // gh-2
 	public void shouldTranslateDuplicateKeyException() {
 
 		DatabaseClient databaseClient = DatabaseClient.create(connectionFactory);
@@ -128,15 +126,13 @@ public abstract class AbstractDatabaseClientIntegrationTests extends R2dbcIntegr
 				.bindNull(2, Integer.class) //
 				.fetch().rowsUpdated() //
 				.as(StepVerifier::create) //
-				.expectErrorSatisfies(exception -> {
-
-					assertThat(exception).isInstanceOf(DuplicateKeyException.class)
-							.hasMessageContaining("execute; SQL [INSERT INTO legoset");
-				}) //
+				.expectErrorSatisfies(exception -> assertThat(exception) //
+						.isInstanceOf(DuplicateKeyException.class) //
+						.hasMessageContaining("execute; SQL [INSERT INTO legoset")) //
 				.verify();
 	}
 
-	@Test
+	@Test // gh-2
 	public void executeSelect() {
 
 		jdbc.execute("INSERT INTO legoset (id, name, manual) VALUES(42055, 'SCHAUFELRADBAGGER', 12)");
@@ -155,7 +151,7 @@ public abstract class AbstractDatabaseClientIntegrationTests extends R2dbcIntegr
 				}).verifyComplete();
 	}
 
-	@Test
+	@Test // gh-2
 	public void insert() {
 
 		DatabaseClient databaseClient = DatabaseClient.create(connectionFactory);
@@ -172,7 +168,7 @@ public abstract class AbstractDatabaseClientIntegrationTests extends R2dbcIntegr
 		assertThat(jdbc.queryForMap("SELECT id, name, manual FROM legoset")).containsEntry("id", 42055);
 	}
 
-	@Test
+	@Test // gh-2
 	public void insertWithoutResult() {
 
 		DatabaseClient databaseClient = DatabaseClient.create(connectionFactory);
@@ -188,7 +184,7 @@ public abstract class AbstractDatabaseClientIntegrationTests extends R2dbcIntegr
 		assertThat(jdbc.queryForMap("SELECT id, name, manual FROM legoset")).containsEntry("id", 42055);
 	}
 
-	@Test
+	@Test // gh-2
 	public void insertTypedObject() {
 
 		LegoSet legoSet = new LegoSet();
@@ -209,7 +205,7 @@ public abstract class AbstractDatabaseClientIntegrationTests extends R2dbcIntegr
 		assertThat(jdbc.queryForMap("SELECT id, name, manual FROM legoset")).containsEntry("id", 42055);
 	}
 
-	@Test
+	@Test // gh-2
 	public void selectAsMap() {
 
 		jdbc.execute("INSERT INTO legoset (id, name, manual) VALUES(42055, 'SCHAUFELRADBAGGER', 12)");
@@ -229,7 +225,7 @@ public abstract class AbstractDatabaseClientIntegrationTests extends R2dbcIntegr
 				}).verifyComplete();
 	}
 
-	@Test
+	@Test // gh-8
 	public void selectExtracting() {
 
 		jdbc.execute("INSERT INTO legoset (id, name, manual) VALUES(42055, 'SCHAUFELRADBAGGER', 12)");
@@ -246,7 +242,7 @@ public abstract class AbstractDatabaseClientIntegrationTests extends R2dbcIntegr
 				.verifyComplete();
 	}
 
-	@Test
+	@Test // gh-2
 	public void selectOrderByIdDesc() {
 
 		jdbc.execute("INSERT INTO legoset (id, name, manual) VALUES(42055, 'SCHAUFELRADBAGGER', 12)");
@@ -264,7 +260,7 @@ public abstract class AbstractDatabaseClientIntegrationTests extends R2dbcIntegr
 				.verifyComplete();
 	}
 
-	@Test
+	@Test // gh-2
 	public void selectOrderPaged() {
 
 		jdbc.execute("INSERT INTO legoset (id, name, manual) VALUES(42055, 'SCHAUFELRADBAGGER', 12)");
@@ -282,7 +278,7 @@ public abstract class AbstractDatabaseClientIntegrationTests extends R2dbcIntegr
 				.verifyComplete();
 	}
 
-	@Test
+	@Test // gh-2
 	public void selectTypedLater() {
 
 		jdbc.execute("INSERT INTO legoset (id, name, manual) VALUES(42055, 'SCHAUFELRADBAGGER', 12)");
@@ -304,6 +300,7 @@ public abstract class AbstractDatabaseClientIntegrationTests extends R2dbcIntegr
 	@Data
 	@Table("legoset")
 	static class LegoSet {
+
 		int id;
 		String name;
 		Integer manual;

--- a/src/test/java/org/springframework/data/r2dbc/function/AbstractDatabaseClientIntegrationTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/function/AbstractDatabaseClientIntegrationTests.java
@@ -15,8 +15,16 @@
  */
 package org.springframework.data.r2dbc.function;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.data.domain.Sort.Order.*;
+
 import io.r2dbc.spi.ConnectionFactory;
 import lombok.Data;
+import reactor.core.publisher.Hooks;
+import reactor.test.StepVerifier;
+
+import javax.sql.DataSource;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.dao.DataAccessException;
@@ -26,14 +34,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.r2dbc.testing.R2dbcIntegrationTestSupport;
 import org.springframework.data.relational.core.mapping.Table;
 import org.springframework.jdbc.core.JdbcTemplate;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Hooks;
-import reactor.test.StepVerifier;
-
-import javax.sql.DataSource;
-
-import static org.assertj.core.api.Assertions.*;
-import static org.springframework.data.domain.Sort.Order.*;
 
 /**
  * Integration tests for {@link DatabaseClient}.
@@ -57,8 +57,7 @@ public abstract class AbstractDatabaseClientIntegrationTests extends R2dbcIntegr
 
 		try {
 			jdbc.execute("DROP TABLE legoset");
-		} catch (DataAccessException e) {
-		}
+		} catch (DataAccessException e) {}
 		jdbc.execute(getCreateTableStatement());
 	}
 
@@ -106,9 +105,6 @@ public abstract class AbstractDatabaseClientIntegrationTests extends R2dbcIntegr
 				.as(StepVerifier::create) //
 				.expectNext(1) //
 				.verifyComplete();
-
-		Flux<LegoSet> rows = databaseClient.select().from("legoset").orderBy(Sort.by(desc("id"))).as(LegoSet.class).fetch()
-				.all();
 
 		assertThat(jdbc.queryForMap("SELECT id, name, manual FROM legoset")).containsEntry("id", 42055);
 	}

--- a/src/test/java/org/springframework/data/r2dbc/function/AbstractTransactionalDatabaseClientIntegrationTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/function/AbstractTransactionalDatabaseClientIntegrationTests.java
@@ -148,8 +148,7 @@ public abstract class AbstractTransactionalDatabaseClientIntegrationTests extend
 		Queue<Long> transactionIds = new ArrayBlockingQueue<>(5);
 		TransactionalDatabaseClient databaseClient = TransactionalDatabaseClient.create(connectionFactory);
 
-		Flux<Long> txId = databaseClient.execute().sql(getCurrentTransactionIdStatement()).exchange()
-				.flatMapMany(it -> it.extract((r, md) -> r.get(0, Long.class)).all());
+		Flux<Long> txId = databaseClient.execute().sql(getCurrentTransactionIdStatement()).map((r, md) -> r.get(0, Long.class)).all();
 
 		Mono<Void> then = databaseClient.enableTransactionSynchronization(databaseClient.beginTransaction() //
 				.thenMany(txId.concatWith(txId).doOnNext(transactionIds::add)) //
@@ -207,8 +206,7 @@ public abstract class AbstractTransactionalDatabaseClientIntegrationTests extend
 
 		Flux<Object> transactionIds = databaseClient.inTransaction(db -> {
 
-			Flux<Object> txId = db.execute().sql(getCurrentTransactionIdStatement()).exchange()
-					.flatMapMany(it -> it.extract((r, md) -> r.get(0)).all());
+			Flux<Object> txId = db.execute().sql(getCurrentTransactionIdStatement()).map((r, md) -> r.get(0)).all();
 			return txId.concatWith(txId);
 		});
 


### PR DESCRIPTION
`DatabaseClient` now no longer exposes the `exchange()` method but rather provides `map(…)` and `then(…)` methods. Calling `map(…)` extracts values from tabular results by propagating the mapping function to `Result.map(…)`. `then()` allows statement execution without returning the result propagating only completion and error signals.

---

Related ticket: #8.

/cc @sdeleuze @odrotbohm