### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC.</description>
-	<url>http://projects.spring.io/spring-data-r2dbc</url>
+	<url>https://projects.spring.io/spring-data-r2dbc</url>
 
 	<parent>
 		<groupId>org.springframework.data.build</groupId>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://projects.spring.io/spring-data-r2dbc migrated to:  
  https://projects.spring.io/spring-data-r2dbc ([https](https://projects.spring.io/spring-data-r2dbc) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance