### PR TITLE
#75 - Add support for MySQL using jasync-mysql

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,8 @@
 		<degraph-check.version>0.1.4</degraph-check.version>
 		<hsqldb.version>2.4.1</hsqldb.version>
 		<postgresql.version>42.2.5</postgresql.version>
+		<mysql.version>5.1.47</mysql.version>
+		<jasync.version>0.9.38</jasync.version>
 		<mssql-jdbc.version>7.1.2.jre8-preview</mssql-jdbc.version>
 		<r2dbc-releasetrain.version>Arabba-M7</r2dbc-releasetrain.version>
 		<reactive-streams.version>1.0.1</reactive-streams.version>
@@ -174,6 +176,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>mysql</groupId>
+			<artifactId>mysql-connector-java</artifactId>
+			<version>${mysql.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
 			<version>${mssql-jdbc.version}</version>
@@ -195,6 +204,13 @@
 		<dependency>
 			<groupId>io.r2dbc</groupId>
 			<artifactId>r2dbc-mssql</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.github.jasync-sql</groupId>
+			<artifactId>jasync-r2dbc-mysql</artifactId>
+			<version>${jasync.version}</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -295,7 +311,8 @@
 						<querydslVersion>${querydsl}</querydslVersion>
 						<springVersion>${spring}</springVersion>
 						<r2dbcVersion>${r2dbc-spi.version}</r2dbcVersion>
-						<reactiveStreamsVersion>${reactive-streams.version}</reactiveStreamsVersion>
+						<reactiveStreamsVersion>${reactive-streams.version}
+						</reactiveStreamsVersion>
 						<releasetrainVersion>${releasetrain}</releasetrainVersion>
 						<allow-uri-read>true</allow-uri-read>
 						<toclevels>3</toclevels>
@@ -415,6 +432,10 @@
 		<repository>
 			<id>spring-libs-snapshot</id>
 			<url>https://repo.spring.io/libs-snapshot</url>
+		</repository>
+		<repository>
+			<id>jcenter</id>
+			<url>https://jcenter.bintray.com/</url>
 		</repository>
 	</repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<version>1.0.0.gh-75-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC.</description>

--- a/src/main/java/org/springframework/data/r2dbc/dialect/AnonymousBindMarkers.java
+++ b/src/main/java/org/springframework/data/r2dbc/dialect/AnonymousBindMarkers.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/org/springframework/data/r2dbc/dialect/AnonymousBindMarkers.java
+++ b/src/main/java/org/springframework/data/r2dbc/dialect/AnonymousBindMarkers.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.dialect;
+
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
+/**
+ * Anonymous, index-based bind marker using a static placeholder. Instances are bound by the ordinal position ordered by
+ * the appearance of the placeholder. This implementation creates indexed bind markers using an anonymous placeholder
+ * that correlates with an index.
+ *
+ * @author Mark Paluch
+ */
+class AnonymousBindMarkers implements BindMarkers {
+
+	private static final AtomicIntegerFieldUpdater<AnonymousBindMarkers> COUNTER_INCREMENTER = AtomicIntegerFieldUpdater
+			.newUpdater(AnonymousBindMarkers.class, "counter");
+
+	// access via COUNTER_INCREMENTER
+	@SuppressWarnings("unused") private volatile int counter;
+
+	private final String placeholder;
+
+	/**
+	 * Creates a new {@link AnonymousBindMarkers} instance given {@code placeholder}.
+	 *
+	 * @param placeholder parameter bind marker.
+	 */
+	AnonymousBindMarkers(String placeholder) {
+		this.counter = 0;
+		this.placeholder = placeholder;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.r2dbc.dialect.BindMarkers#next()
+	 */
+	@Override
+	public BindMarker next() {
+
+		int index = COUNTER_INCREMENTER.getAndIncrement(this);
+
+		return new IndexedBindMarker(placeholder, index);
+	}
+
+}

--- a/src/main/java/org/springframework/data/r2dbc/dialect/BindMarkersFactory.java
+++ b/src/main/java/org/springframework/data/r2dbc/dialect/BindMarkersFactory.java
@@ -44,6 +44,22 @@ public interface BindMarkersFactory {
 	}
 
 	/**
+	 * Creates anonymous, index-based bind marker using a static placeholder. Instances are bound by the ordinal position
+	 * ordered by the appearance of the placeholder. This implementation creates indexed bind markers using an anonymous
+	 * placeholder that correlates with an index.
+	 *
+	 * @param placeholder parameter placeholder.
+	 * @return a {@link BindMarkersFactory} using {@code placeholder}.
+	 * @see io.r2dbc.spi.Statement#bindNull(int, Class)
+	 * @see io.r2dbc.spi.Statement#bind(int, Object)
+	 */
+	static BindMarkersFactory anonymous(String placeholder) {
+
+		Assert.hasText(placeholder, "Placeholder must not be empty!");
+		return () -> new AnonymousBindMarkers(placeholder);
+	}
+
+	/**
 	 * Create named {@link BindMarkers} using identifiers to bind parameters. Named bind markers can support
 	 * {@link BindMarkers#next(String) name hints}. If no {@link BindMarkers#next(String) hint} is given, named bind
 	 * markers can use a counter or a random value source to generate unique bind markers.

--- a/src/main/java/org/springframework/data/r2dbc/dialect/Database.java
+++ b/src/main/java/org/springframework/data/r2dbc/dialect/Database.java
@@ -53,6 +53,18 @@ public enum Database {
 		public Dialect defaultDialect() {
 			return H2Dialect.INSTANCE;
 		}
+	},
+
+	MYSQL {
+		@Override
+		public String driverName() {
+			return "MySQL";
+		}
+
+		@Override
+		public Dialect defaultDialect() {
+			return MySqlDialect.INSTANCE;
+		}
 	};
 
 	/**

--- a/src/main/java/org/springframework/data/r2dbc/dialect/IndexedBindMarker.java
+++ b/src/main/java/org/springframework/data/r2dbc/dialect/IndexedBindMarker.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/org/springframework/data/r2dbc/dialect/IndexedBindMarker.java
+++ b/src/main/java/org/springframework/data/r2dbc/dialect/IndexedBindMarker.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.dialect;
+
+import io.r2dbc.spi.Statement;
+
+/**
+ * A single indexed bind marker.
+ */
+class IndexedBindMarker implements BindMarker {
+
+	private final String placeholder;
+
+	private int index;
+
+	IndexedBindMarker(String placeholder, int index) {
+		this.placeholder = placeholder;
+		this.index = index;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.r2dbc.dialect.BindMarker#getPlaceholder()
+	 */
+	@Override
+	public String getPlaceholder() {
+		return placeholder;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.r2dbc.dialect.BindMarker#bindValue(io.r2dbc.spi.Statement, java.lang.Object)
+	 */
+	@Override
+	public void bind(Statement statement, Object value) {
+		statement.bind(this.index, value);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.r2dbc.dialect.BindMarker#bindNull(io.r2dbc.spi.Statement, java.lang.Class)
+	 */
+	@Override
+	public void bindNull(Statement statement, Class<?> valueType) {
+		statement.bindNull(this.index, valueType);
+	}
+}

--- a/src/main/java/org/springframework/data/r2dbc/dialect/IndexedBindMarkers.java
+++ b/src/main/java/org/springframework/data/r2dbc/dialect/IndexedBindMarkers.java
@@ -1,7 +1,5 @@
 package org.springframework.data.r2dbc.dialect;
 
-import io.r2dbc.spi.Statement;
-
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 /**
@@ -44,47 +42,5 @@ class IndexedBindMarkers implements BindMarkers {
 		int index = COUNTER_INCREMENTER.getAndIncrement(this);
 
 		return new IndexedBindMarker(prefix + "" + (index + offset), index);
-	}
-
-	/**
-	 * A single indexed bind marker.
-	 */
-	static class IndexedBindMarker implements BindMarker {
-
-		private final String placeholder;
-
-		private int index;
-
-		IndexedBindMarker(String placeholder, int index) {
-			this.placeholder = placeholder;
-			this.index = index;
-		}
-
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.r2dbc.dialect.BindMarker#getPlaceholder()
-		 */
-		@Override
-		public String getPlaceholder() {
-			return placeholder;
-		}
-
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.r2dbc.dialect.BindMarker#bindValue(io.r2dbc.spi.Statement, java.lang.Object)
-		 */
-		@Override
-		public void bind(Statement statement, Object value) {
-			statement.bind(this.index, value);
-		}
-
-		/*
-		 * (non-Javadoc)
-		 * @see org.springframework.data.r2dbc.dialect.BindMarker#bindNull(io.r2dbc.spi.Statement, java.lang.Class)
-		 */
-		@Override
-		public void bindNull(Statement statement, Class<?> valueType) {
-			statement.bindNull(this.index, valueType);
-		}
 	}
 }

--- a/src/main/java/org/springframework/data/r2dbc/dialect/MySqlDialect.java
+++ b/src/main/java/org/springframework/data/r2dbc/dialect/MySqlDialect.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.dialect;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * An SQL dialect for MySQL.
+ *
+ * @author Mark Paluch
+ */
+public class MySqlDialect implements Dialect {
+
+	private static final Set<Class<?>> SIMPLE_TYPES = new HashSet<>(
+			Arrays.asList(UUID.class, URL.class, URI.class, InetAddress.class));
+
+	/**
+	 * Singleton instance.
+	 */
+	public static final MySqlDialect INSTANCE = new MySqlDialect();
+
+	private static final BindMarkersFactory ANONYMOUS = BindMarkersFactory.anonymous("?");
+
+	private static final LimitClause LIMIT_CLAUSE = new LimitClause() {
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.r2dbc.dialect.LimitClause#getClause(long, long)
+		 */
+		@Override
+		public String getClause(long limit, long offset) {
+			return String.format("LIMIT %d,%d", limit, offset);
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.r2dbc.dialect.LimitClause#getClause(long)
+		 */
+		@Override
+		public String getClause(long limit) {
+			return "LIMIT " + limit;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.r2dbc.dialect.LimitClause#getClausePosition()
+		 */
+		@Override
+		public Position getClausePosition() {
+			return Position.END;
+		}
+	};
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.r2dbc.dialect.Dialect#getBindMarkersFactory()
+	 */
+	@Override
+	public BindMarkersFactory getBindMarkersFactory() {
+		return ANONYMOUS;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.r2dbc.dialect.Dialect#getSimpleTypesKeys()
+	 */
+	@Override
+	public Collection<? extends Class<?>> getSimpleTypes() {
+		return SIMPLE_TYPES;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.r2dbc.dialect.Dialect#limit()
+	 */
+	@Override
+	public LimitClause limit() {
+		return LIMIT_CLAUSE;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.r2dbc.dialect.Dialect#getArraySupport()
+	 */
+	@Override
+	public ArrayColumns getArraySupport() {
+		return ArrayColumns.Unsupported.INSTANCE;
+	}
+}

--- a/src/test/java/org/springframework/data/r2dbc/dialect/AnonymousBindMarkersUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/dialect/AnonymousBindMarkersUnitTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/org/springframework/data/r2dbc/dialect/AnonymousBindMarkersUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/dialect/AnonymousBindMarkersUnitTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.dialect;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.r2dbc.spi.Statement;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link AnonymousBindMarkers}.
+ *
+ * @author Mark Paluch
+ */
+public class AnonymousBindMarkersUnitTests {
+
+	@Test // gh-75
+	public void shouldCreateNewBindMarkers() {
+
+		BindMarkersFactory factory = BindMarkersFactory.anonymous("?");
+
+		BindMarkers bindMarkers1 = factory.create();
+		BindMarkers bindMarkers2 = factory.create();
+
+		assertThat(bindMarkers1.next().getPlaceholder()).isEqualTo("?");
+		assertThat(bindMarkers2.next().getPlaceholder()).isEqualTo("?");
+	}
+
+	@Test // gh-75
+	public void shouldBindByIndex() {
+
+		Statement statement = mock(Statement.class);
+
+		BindMarkers bindMarkers = BindMarkersFactory.anonymous("?").create();
+
+		BindMarker first = bindMarkers.next();
+		BindMarker second = bindMarkers.next();
+
+		second.bind(statement, "foo");
+		first.bindNull(statement, Object.class);
+
+		verify(statement).bindNull(0, Object.class);
+		verify(statement).bind(1, "foo");
+	}
+}

--- a/src/test/java/org/springframework/data/r2dbc/function/MySqlDatabaseClientIntegrationTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/function/MySqlDatabaseClientIntegrationTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.function;
+
+import io.r2dbc.spi.ConnectionFactory;
+
+import javax.sql.DataSource;
+
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import org.springframework.data.r2dbc.testing.ExternalDatabase;
+import org.springframework.data.r2dbc.testing.MySqlTestSupport;
+
+/**
+ * Integration tests for {@link DatabaseClient} against MySQL.
+ *
+ * @author Mark Paluch
+ */
+public class MySqlDatabaseClientIntegrationTests extends AbstractDatabaseClientIntegrationTests {
+
+	@ClassRule public static final ExternalDatabase database = MySqlTestSupport.database();
+
+	@Override
+	protected DataSource createDataSource() {
+		return MySqlTestSupport.createDataSource(database);
+	}
+
+	@Override
+	protected ConnectionFactory createConnectionFactory() {
+		return MySqlTestSupport.createConnectionFactory(database);
+	}
+
+	@Override
+	protected String getCreateTableStatement() {
+		return MySqlTestSupport.CREATE_TABLE_LEGOSET;
+	}
+
+	@Override
+	@Ignore("Jasync currently uses its own exceptions, see jasync-sql/jasync-sql#106")
+	@Test
+	public void shouldTranslateDuplicateKeyException() {}
+}

--- a/src/test/java/org/springframework/data/r2dbc/function/MySqlTransactionalDatabaseClientIntegrationTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/function/MySqlTransactionalDatabaseClientIntegrationTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.function;
+
+import io.r2dbc.spi.ConnectionFactory;
+
+import javax.sql.DataSource;
+
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import org.springframework.data.r2dbc.testing.ExternalDatabase;
+import org.springframework.data.r2dbc.testing.MySqlTestSupport;
+
+/**
+ * Integration tests for {@link TransactionalDatabaseClient} against MySQL.
+ *
+ * @author Mark Paluch
+ */
+public class MySqlTransactionalDatabaseClientIntegrationTests
+		extends AbstractTransactionalDatabaseClientIntegrationTests {
+
+	@ClassRule public static final ExternalDatabase database = MySqlTestSupport.database();
+
+	@Override
+	protected DataSource createDataSource() {
+		return MySqlTestSupport.createDataSource(database);
+	}
+
+	@Override
+	protected ConnectionFactory createConnectionFactory() {
+		return MySqlTestSupport.createConnectionFactory(database);
+	}
+
+	@Override
+	protected String getCreateTableStatement() {
+		return MySqlTestSupport.CREATE_TABLE_LEGOSET;
+	}
+
+	@Override
+	protected String getCurrentTransactionIdStatement() {
+		return "SELECT tx.trx_id FROM information_schema.innodb_trx tx WHERE tx.trx_mysql_thread_id = connection_id()";
+	}
+
+	@Override
+	@Test
+	@Ignore("MySQL creates transactions only on interaction with transactional tables. BEGIN does not create a txid")
+	public void shouldManageUserTransaction() {}
+}

--- a/src/test/java/org/springframework/data/r2dbc/repository/AbstractR2dbcRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/AbstractR2dbcRepositoryIntegrationTests.java
@@ -188,16 +188,16 @@ public abstract class AbstractR2dbcRepositoryIntegrationTests extends R2dbcInteg
 		Flux<Map<String, Object>> transactional = client.inTransaction(db -> {
 
 			return transactionalRepository.save(legoSet1) //
-					.map(it -> jdbc.queryForMap("SELECT count(*) FROM legoset"));
+					.map(it -> jdbc.queryForMap("SELECT count(*) as count FROM legoset"));
 		});
 
 		Mono<Map<String, Object>> nonTransactional = transactionalRepository.save(legoSet2) //
-				.map(it -> jdbc.queryForMap("SELECT count(*) FROM legoset"));
+				.map(it -> jdbc.queryForMap("SELECT count(*) as count FROM legoset"));
 
 		transactional.as(StepVerifier::create).expectNext(Collections.singletonMap("count", 0L)).verifyComplete();
 		nonTransactional.as(StepVerifier::create).expectNext(Collections.singletonMap("count", 2L)).verifyComplete();
 
-		Map<String, Object> count = jdbc.queryForMap("SELECT count(*) FROM legoset");
+		Map<String, Object> count = jdbc.queryForMap("SELECT count(*) as count FROM legoset");
 		assertThat(count).containsEntry("count", 2L);
 	}
 

--- a/src/test/java/org/springframework/data/r2dbc/repository/MySqlR2dbcRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/MySqlR2dbcRepositoryIntegrationTests.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.repository;
+
+import io.r2dbc.spi.ConnectionFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import javax.sql.DataSource;
+
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.r2dbc.config.AbstractR2dbcConfiguration;
+import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
+import org.springframework.data.r2dbc.repository.query.Query;
+import org.springframework.data.r2dbc.repository.support.R2dbcRepositoryFactory;
+import org.springframework.data.r2dbc.testing.ExternalDatabase;
+import org.springframework.data.r2dbc.testing.MySqlTestSupport;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * Integration tests for {@link LegoSetRepository} using {@link R2dbcRepositoryFactory} against MySQL.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration
+public class MySqlR2dbcRepositoryIntegrationTests extends AbstractR2dbcRepositoryIntegrationTests {
+
+	@ClassRule public static final ExternalDatabase database = MySqlTestSupport.database();
+
+	@Configuration
+	@EnableR2dbcRepositories(considerNestedRepositories = true,
+			includeFilters = @Filter(classes = MySqlLegoSetRepository.class, type = FilterType.ASSIGNABLE_TYPE))
+	static class IntegrationTestConfiguration extends AbstractR2dbcConfiguration {
+
+		@Override
+		public ConnectionFactory connectionFactory() {
+			return MySqlTestSupport.createConnectionFactory(database);
+		}
+	}
+
+	@Override
+	protected DataSource createDataSource() {
+		return MySqlTestSupport.createDataSource(database);
+	}
+
+	@Override
+	protected ConnectionFactory createConnectionFactory() {
+		return MySqlTestSupport.createConnectionFactory(database);
+	}
+
+	@Override
+	protected String getCreateTableStatement() {
+		return MySqlTestSupport.CREATE_TABLE_LEGOSET_WITH_ID_GENERATION;
+	}
+
+	@Override
+	protected Class<? extends LegoSetRepository> getRepositoryInterfaceType() {
+		return MySqlLegoSetRepository.class;
+	}
+
+	interface MySqlLegoSetRepository extends LegoSetRepository {
+
+		@Override
+		@Query("SELECT * FROM legoset WHERE name like ?")
+		Flux<LegoSet> findByNameContains(String name);
+
+		@Override
+		@Query("SELECT * FROM legoset")
+		Flux<Named> findAsProjection();
+
+		@Override
+		@Query("SELECT * FROM legoset WHERE manual = :manual")
+		Mono<LegoSet> findByManual(int manual);
+
+		@Override
+		@Query("SELECT id FROM legoset")
+		Flux<Integer> findAllIds();
+	}
+}

--- a/src/test/java/org/springframework/data/r2dbc/testing/ConnectionUtils.java
+++ b/src/test/java/org/springframework/data/r2dbc/testing/ConnectionUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.testing;
+
+import static io.r2dbc.spi.ConnectionFactoryOptions.*;
+
+import io.r2dbc.spi.ConnectionFactories;
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+
+import javax.sql.DataSource;
+
+/**
+ * Utility methods to configure {@link DataSource}/{@link ConnectionFactoryOptions}.
+ *
+ * @author Mark Paluch
+ */
+abstract class ConnectionUtils {
+
+	/**
+	 * Obtain a {@link ConnectionFactory} given {@link ExternalDatabase} and {@code driver}.
+	 *
+	 * @param driver
+	 * @param configuration
+	 * @return
+	 */
+	static ConnectionFactory getConnectionFactory(String driver, ExternalDatabase configuration) {
+		return ConnectionFactories.get(createOptions(driver, configuration));
+	}
+
+	/**
+	 * Create {@link ConnectionFactoryOptions} from {@link ExternalDatabase} and {@code driver}.
+	 *
+	 * @param driver
+	 * @param configuration
+	 * @return
+	 */
+	private static ConnectionFactoryOptions createOptions(String driver, ExternalDatabase configuration) {
+
+		return ConnectionFactoryOptions.builder().option(DRIVER, driver) //
+				.option(USER, configuration.getUsername()) //
+				.option(PASSWORD, configuration.getPassword()) //
+				.option(DATABASE, configuration.getDatabase()) //
+				.option(HOST, configuration.getHostname()) //
+				.option(PORT, configuration.getPort()) //
+				.build();
+	}
+
+	private ConnectionUtils() {
+		// utility constructor.
+	}
+}

--- a/src/test/java/org/springframework/data/r2dbc/testing/MySqlTestSupport.java
+++ b/src/test/java/org/springframework/data/r2dbc/testing/MySqlTestSupport.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.testing;
+
+import io.r2dbc.spi.ConnectionFactory;
+
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import javax.sql.DataSource;
+
+import org.springframework.data.r2dbc.testing.ExternalDatabase.ProvidedDatabase;
+
+import org.testcontainers.containers.MySQLContainer;
+
+import com.github.jasync.r2dbc.mysql.JasyncConnectionFactory;
+import com.github.jasync.sql.db.Configuration;
+import com.github.jasync.sql.db.mysql.pool.MySQLConnectionFactory;
+import com.mysql.jdbc.jdbc2.optional.MysqlDataSource;
+
+/**
+ * Utility class for testing against MySQL.
+ *
+ * @author Mark Paluch
+ */
+public class MySqlTestSupport {
+
+	private static ExternalDatabase testContainerDatabase;
+
+	public static String CREATE_TABLE_LEGOSET = "CREATE TABLE legoset (\n" //
+			+ "    id          integer PRIMARY KEY,\n" //
+			+ "    name        varchar(255) NOT NULL,\n" //
+			+ "    manual      integer NULL\n" //
+			+ ") ENGINE=InnoDB;";
+
+	public static String CREATE_TABLE_LEGOSET_WITH_ID_GENERATION = "CREATE TABLE legoset (\n" //
+			+ "    id          integer AUTO_INCREMENT PRIMARY KEY,\n" //
+			+ "    name        varchar(255) NOT NULL,\n" //
+			+ "    manual      integer NULL\n" //
+			+ ") ENGINE=InnoDB;";
+
+	/**
+	 * Returns a database either hosted locally at {@code postgres:@localhost:5432/postgres} or running inside Docker.
+	 *
+	 * @return information about the database. Guaranteed to be not {@literal null}.
+	 */
+	public static ExternalDatabase database() {
+
+		if (Boolean.getBoolean("spring.data.r2dbc.test.preferLocalDatabase")) {
+
+			return getFirstWorkingDatabase( //
+					MySqlTestSupport::local, //
+					MySqlTestSupport::testContainer //
+			);
+		} else {
+
+			return getFirstWorkingDatabase( //
+					MySqlTestSupport::testContainer, //
+					MySqlTestSupport::local //
+			);
+		}
+	}
+
+	@SafeVarargs
+	private static ExternalDatabase getFirstWorkingDatabase(Supplier<ExternalDatabase>... suppliers) {
+
+		return Stream.of(suppliers).map(Supplier::get) //
+				.filter(ExternalDatabase::checkValidity) //
+				.findFirst() //
+				.orElse(ExternalDatabase.unavailable());
+	}
+
+	/**
+	 * Returns a locally provided database at {@code postgres:@localhost:5432/postgres}.
+	 */
+	private static ExternalDatabase local() {
+
+		return ProvidedDatabase.builder() //
+				.hostname("localhost") //
+				.port(3306) //
+				.database("mysql") //
+				.username("root") //
+				.password("my-secret-pw").build();
+	}
+
+	/**
+	 * Returns a database provided via Testcontainers.
+	 */
+	private static ExternalDatabase testContainer() {
+
+		if (testContainerDatabase == null) {
+
+			try {
+				MySQLContainer mySQLContainer = new MySQLContainer("mysql:5.6.43");
+				mySQLContainer.start();
+
+				testContainerDatabase = ProvidedDatabase.builder() //
+						.hostname("localhost") //
+						.port(mySQLContainer.getFirstMappedPort()) //
+						.database(mySQLContainer.getDatabaseName()) //
+						.username("root") //
+						.password(mySQLContainer.getPassword()).build();
+			} catch (IllegalStateException ise) {
+				// docker not available.
+				testContainerDatabase = ExternalDatabase.unavailable();
+			}
+		}
+
+		return testContainerDatabase;
+	}
+
+	/**
+	 * Creates a new {@link ConnectionFactory} configured from the {@link ExternalDatabase}..
+	 */
+	public static ConnectionFactory createConnectionFactory(ExternalDatabase database) {
+
+		MySQLConnectionFactory jasync = new MySQLConnectionFactory(new Configuration(database.getUsername(),
+				database.getHostname(), database.getPort(), database.getPassword(), database.getDatabase()));
+		return new JasyncConnectionFactory(jasync);
+	}
+
+	/**
+	 * Creates a new {@link DataSource} configured from the {@link ExternalDatabase}.
+	 */
+	public static DataSource createDataSource(ExternalDatabase database) {
+
+		MysqlDataSource dataSource = new MysqlDataSource();
+
+		dataSource.setUser(database.getUsername());
+		dataSource.setPassword(database.getPassword());
+		dataSource.setDatabaseName(database.getDatabase());
+		dataSource.setServerName(database.getHostname());
+		dataSource.setPortNumber(database.getPort());
+
+		return dataSource;
+	}
+
+}

--- a/src/test/java/org/springframework/data/r2dbc/testing/SqlServerTestSupport.java
+++ b/src/test/java/org/springframework/data/r2dbc/testing/SqlServerTestSupport.java
@@ -1,7 +1,5 @@
 package org.springframework.data.r2dbc.testing;
 
-import io.r2dbc.mssql.MssqlConnectionConfiguration;
-import io.r2dbc.mssql.MssqlConnectionFactory;
 import io.r2dbc.spi.ConnectionFactory;
 
 import javax.sql.DataSource;
@@ -53,16 +51,10 @@ public class SqlServerTestSupport {
 	}
 
 	/**
-	 * Creates a new {@link ConnectionFactory} configured from the {@link ExternalDatabase}..
+	 * Creates a new {@link ConnectionFactory} configured from the {@link ExternalDatabase}.
 	 */
 	public static ConnectionFactory createConnectionFactory(ExternalDatabase database) {
-
-		return new MssqlConnectionFactory(MssqlConnectionConfiguration.builder().host(database.getHostname()) //
-				.database(database.getDatabase()) //
-				.username(database.getUsername()) //
-				.password(database.getPassword()) //
-				.port(database.getPort()) //
-				.build());
+		return ConnectionUtils.getConnectionFactory("mssql", database);
 	}
 
 	/**
@@ -74,9 +66,7 @@ public class SqlServerTestSupport {
 
 		dataSource.setUser(database.getUsername());
 		dataSource.setPassword(database.getPassword());
-		dataSource.setDatabaseName(database.getDatabase());
-		dataSource.setServerName(database.getHostname());
-		dataSource.setPortNumber(database.getPort());
+		dataSource.setURL(database.getJdbcUrl());
 
 		return dataSource;
 	}


### PR DESCRIPTION
We now support MySQL through the jasync-mysql driver that exposes its asynchronous functionality through a R2DBC wrapper implementation.

Jasync uses for now its own exceptions. We also introduced support for anonymous bind markers which use ordinal binding an a static placeholder.

---

Related ticket: #75.