### PR TITLE
Emit inserted object through SimpleR2dbcRepository.save(…) with given Id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<version>1.0.0.gh-90-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC.</description>

--- a/src/main/java/org/springframework/data/r2dbc/repository/support/SimpleR2dbcRepository.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/support/SimpleR2dbcRepository.java
@@ -75,7 +75,8 @@ public class SimpleR2dbcRepository<T, ID> implements ReactiveCrudRepository<T, I
 					.into(entity.getJavaType()) //
 					.using(objectToSave) //
 					.map(converter.populateIdIfNecessary(objectToSave)) //
-					.one();
+					.first() //
+					.defaultIfEmpty(objectToSave);
 		}
 
 		Object id = entity.getRequiredId(objectToSave);

--- a/src/test/java/org/springframework/data/r2dbc/function/H2DatabaseClientIntegrationTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/function/H2DatabaseClientIntegrationTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.function;
+
+import io.r2dbc.spi.ConnectionFactory;
+
+import javax.sql.DataSource;
+
+import org.junit.Ignore;
+
+import org.springframework.data.r2dbc.testing.H2TestSupport;
+
+/**
+ * Integration tests for {@link DatabaseClient} against H2.
+ *
+ * @author Mark Paluch
+ */
+public class H2DatabaseClientIntegrationTests extends AbstractDatabaseClientIntegrationTests {
+
+	@Override
+	protected DataSource createDataSource() {
+		return H2TestSupport.createDataSource();
+	}
+
+	@Override
+	protected ConnectionFactory createConnectionFactory() {
+		return H2TestSupport.createConnectionFactory();
+	}
+
+	@Override
+	protected String getCreateTableStatement() {
+		return H2TestSupport.CREATE_TABLE_LEGOSET;
+	}
+
+	@Override
+	@Ignore("See https://github.com/r2dbc/r2dbc-h2/issues/66")
+	public void shouldTranslateDuplicateKeyException() {}
+}

--- a/src/test/java/org/springframework/data/r2dbc/repository/AbstractR2dbcRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/AbstractR2dbcRepositoryIntegrationTests.java
@@ -188,16 +188,16 @@ public abstract class AbstractR2dbcRepositoryIntegrationTests extends R2dbcInteg
 		Flux<Map<String, Object>> transactional = client.inTransaction(db -> {
 
 			return transactionalRepository.save(legoSet1) //
-					.map(it -> jdbc.queryForMap("SELECT count(*) FROM legoset"));
+					.map(it -> jdbc.queryForMap("SELECT count(*) as count FROM legoset"));
 		});
 
 		Mono<Map<String, Object>> nonTransactional = transactionalRepository.save(legoSet2) //
-				.map(it -> jdbc.queryForMap("SELECT count(*) FROM legoset"));
+				.map(it -> jdbc.queryForMap("SELECT count(*) as count FROM legoset"));
 
 		transactional.as(StepVerifier::create).expectNext(Collections.singletonMap("count", 0L)).verifyComplete();
 		nonTransactional.as(StepVerifier::create).expectNext(Collections.singletonMap("count", 2L)).verifyComplete();
 
-		Map<String, Object> count = jdbc.queryForMap("SELECT count(*) FROM legoset");
+		Map<String, Object> count = jdbc.queryForMap("SELECT count(*) as count FROM legoset");
 		assertThat(count).containsEntry("count", 2L);
 	}
 

--- a/src/test/java/org/springframework/data/r2dbc/repository/H2R2dbcRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/H2R2dbcRepositoryIntegrationTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.repository;
+
+import io.r2dbc.spi.ConnectionFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import javax.sql.DataSource;
+
+import org.junit.runner.RunWith;
+
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.r2dbc.config.AbstractR2dbcConfiguration;
+import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
+import org.springframework.data.r2dbc.repository.query.Query;
+import org.springframework.data.r2dbc.repository.support.R2dbcRepositoryFactory;
+import org.springframework.data.r2dbc.testing.H2TestSupport;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * Integration tests for {@link LegoSetRepository} using {@link R2dbcRepositoryFactory} against H2.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration
+public class H2R2dbcRepositoryIntegrationTests extends AbstractR2dbcRepositoryIntegrationTests {
+
+	@Configuration
+	@EnableR2dbcRepositories(considerNestedRepositories = true,
+			includeFilters = @Filter(classes = H2LegoSetRepository.class, type = FilterType.ASSIGNABLE_TYPE))
+	static class IntegrationTestConfiguration extends AbstractR2dbcConfiguration {
+
+		@Override
+		public ConnectionFactory connectionFactory() {
+			return H2TestSupport.createConnectionFactory();
+		}
+	}
+
+	@Override
+	protected DataSource createDataSource() {
+		return H2TestSupport.createDataSource();
+	}
+
+	@Override
+	protected ConnectionFactory createConnectionFactory() {
+		return H2TestSupport.createConnectionFactory();
+	}
+
+	@Override
+	protected String getCreateTableStatement() {
+		return H2TestSupport.CREATE_TABLE_LEGOSET_WITH_ID_GENERATION;
+	}
+
+	@Override
+	protected Class<? extends LegoSetRepository> getRepositoryInterfaceType() {
+		return H2LegoSetRepository.class;
+	}
+
+	interface H2LegoSetRepository extends LegoSetRepository {
+
+		@Override
+		@Query("SELECT * FROM legoset WHERE name like $1")
+		Flux<LegoSet> findByNameContains(String name);
+
+		@Override
+		@Query("SELECT * FROM legoset")
+		Flux<Named> findAsProjection();
+
+		@Override
+		@Query("SELECT * FROM legoset WHERE manual = :manual")
+		Mono<LegoSet> findByManual(int manual);
+
+		@Override
+		@Query("SELECT id FROM legoset")
+		Flux<Integer> findAllIds();
+	}
+}

--- a/src/test/java/org/springframework/data/r2dbc/repository/support/AbstractSimpleR2dbcRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/support/AbstractSimpleR2dbcRepositoryIntegrationTests.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.domain.Persistable;
 import org.springframework.data.r2dbc.function.DatabaseClient;
 import org.springframework.data.r2dbc.function.ReactiveDataAccessStrategy;
 import org.springframework.data.r2dbc.function.convert.MappingR2dbcConverter;
@@ -62,8 +63,8 @@ public abstract class AbstractSimpleR2dbcRepositoryIntegrationTests extends R2db
 
 	@Autowired private ReactiveDataAccessStrategy strategy;
 
-	private SimpleR2dbcRepository<LegoSet, Integer> repository;
-	private JdbcTemplate jdbc;
+	SimpleR2dbcRepository<LegoSet, Integer> repository;
+	JdbcTemplate jdbc;
 
 	@Before
 	public void before() {
@@ -372,9 +373,26 @@ public abstract class AbstractSimpleR2dbcRepositoryIntegrationTests extends R2db
 	@Table("legoset")
 	@AllArgsConstructor
 	@NoArgsConstructor
-	static class LegoSet {
+	static class LegoSet implements Persistable<Integer> {
 		@Id Integer id;
 		String name;
 		Integer manual;
+
+		@Override
+		public boolean isNew() {
+			return id == null;
+		}
+	}
+
+	static class AlwaysNewLegoSet extends LegoSet {
+
+		AlwaysNewLegoSet(Integer id, String name, Integer manual) {
+			super(id, name, manual);
+		}
+
+		@Override
+		public boolean isNew() {
+			return true;
+		}
 	}
 }

--- a/src/test/java/org/springframework/data/r2dbc/repository/support/H2SimpleR2dbcRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/support/H2SimpleR2dbcRepositoryIntegrationTests.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.repository.support;
+
+import static org.assertj.core.api.Assertions.*;
+
+import io.r2dbc.spi.ConnectionFactory;
+import reactor.test.StepVerifier;
+
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.r2dbc.config.AbstractR2dbcConfiguration;
+import org.springframework.data.r2dbc.testing.H2TestSupport;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * Integration tests for {@link SimpleR2dbcRepository} against H2.
+ *
+ * @author Mark Paluch
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration
+public class H2SimpleR2dbcRepositoryIntegrationTests extends AbstractSimpleR2dbcRepositoryIntegrationTests {
+
+	@Configuration
+	static class IntegrationTestConfiguration extends AbstractR2dbcConfiguration {
+
+		@Override
+		public ConnectionFactory connectionFactory() {
+			return H2TestSupport.createConnectionFactory();
+		}
+	}
+
+	@Override
+	protected DataSource createDataSource() {
+		return H2TestSupport.createDataSource();
+	}
+
+	@Override
+	protected String getCreateTableStatement() {
+		return H2TestSupport.CREATE_TABLE_LEGOSET_WITH_ID_GENERATION;
+	}
+
+	@Test // gh-90
+	public void shouldInsertNewObjectWithGivenId() {
+
+		try {
+			this.jdbc.execute("DROP TABLE legoset");
+		} catch (DataAccessException e) {}
+
+		this.jdbc.execute(H2TestSupport.CREATE_TABLE_LEGOSET);
+
+		AlwaysNewLegoSet legoSet = new AlwaysNewLegoSet(9999, "SCHAUFELRADBAGGER", 12);
+
+		repository.save(legoSet) //
+				.as(StepVerifier::create) //
+				.consumeNextWith(actual -> {
+
+					assertThat(actual.getId()).isEqualTo(9999);
+				}).verifyComplete();
+
+		Map<String, Object> map = jdbc.queryForMap("SELECT * FROM legoset");
+		assertThat(map).containsEntry("name", "SCHAUFELRADBAGGER").containsEntry("manual", 12).containsKey("id");
+	}
+}

--- a/src/test/java/org/springframework/data/r2dbc/testing/H2TestSupport.java
+++ b/src/test/java/org/springframework/data/r2dbc/testing/H2TestSupport.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.testing;
+
+import io.r2dbc.h2.H2ConnectionConfiguration;
+import io.r2dbc.h2.H2ConnectionFactory;
+import io.r2dbc.spi.ConnectionFactory;
+
+import javax.sql.DataSource;
+
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+/**
+ * Utility class for testing against H2.
+ *
+ * @author Mark Paluch
+ */
+public class H2TestSupport {
+
+	public static String CREATE_TABLE_LEGOSET = "CREATE TABLE legoset (\n" //
+			+ "    id          integer CONSTRAINT id PRIMARY KEY,\n" //
+			+ "    name        varchar(255) NOT NULL,\n" //
+			+ "    manual      integer NULL\n" //
+			+ ");";
+
+	public static String CREATE_TABLE_LEGOSET_WITH_ID_GENERATION = "CREATE TABLE legoset (\n" //
+			+ "    id          serial CONSTRAINT id PRIMARY KEY,\n" //
+			+ "    name        varchar(255) NOT NULL,\n" //
+			+ "    manual      integer NULL\n" //
+			+ ");";
+
+	/**
+	 * Creates a new {@link ConnectionFactory}.
+	 */
+	public static ConnectionFactory createConnectionFactory() {
+
+		return new H2ConnectionFactory(H2ConnectionConfiguration.builder() //
+				.inMemory("r2dbc") //
+				.username("sa") //
+				.password("") //
+				.option("DB_CLOSE_DELAY=-1").build());
+	}
+
+	/**
+	 * Creates a new {@link DataSource}.
+	 */
+	public static DataSource createDataSource() {
+
+		DriverManagerDataSource dataSource = new DriverManagerDataSource();
+
+		dataSource.setUsername("sa");
+		dataSource.setPassword("");
+		dataSource.setUrl("jdbc:h2:mem:r2dbc;DB_CLOSE_DELAY=-1");
+
+		return dataSource;
+	}
+
+}


### PR DESCRIPTION
`SimpleR2dbcRepository.save(…)` now falls back to the saved object as an emitted result if the `INSERT` statement does not return generated keys.

Adding H2 database engine for tests to simulate such behavior.

---

Related ticket: #90.