### PR TITLE
Accept SQL directly in DatabaseClient.execute(…) stage.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>1.0.0.BUILD-SNAPSHOT</version>
+	<version>1.0.0.gh-89-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC.</description>

--- a/src/main/asciidoc/reference/r2dbc.adoc
+++ b/src/main/asciidoc/reference/r2dbc.adoc
@@ -132,8 +132,7 @@ public class R2dbcApp {
 
     DatabaseClient client = DatabaseClient.create(connectionFactory);
 
-    client.execute()
-            .sql("CREATE TABLE person" +
+    client.execute("CREATE TABLE person" +
                     "(id VARCHAR(255) PRIMARY KEY," +
                     "name VARCHAR(255)," +
                     "age INT)")
@@ -349,8 +348,7 @@ The following example shows what you need to include for a minimal but fully fun
 
 [source,java]
 ----
-Mono<Void> completion = client.execute()
-        .sql("CREATE TABLE person (id VARCHAR(255) PRIMARY KEY, name VARCHAR(255), age INTEGER);")
+Mono<Void> completion = client.execute("CREATE TABLE person (id VARCHAR(255) PRIMARY KEY, name VARCHAR(255), age INTEGER);")
         .then();
 ----
 
@@ -358,7 +356,7 @@ Mono<Void> completion = client.execute()
 It exposes intermediate, continuation, and terminal methods at each stage of the execution specification.
 The example above uses `then()` to return a completion `Publisher` that completes as soon as the query (or queries, if the SQL query contains multiple statements) completes.
 
-NOTE: `execute().sql(…)` accepts either the SQL query string or a query `Supplier<String>` to defer the actual query creation until execution.
+NOTE: `execute(…)` accepts either the SQL query string or a query `Supplier<String>` to defer the actual query creation until execution.
 
 [[r2dbc.datbaseclient.queries]]
 === Running Queries
@@ -370,8 +368,7 @@ The following example shows an `UPDATE` statement that returns the number of upd
 
 [source,java]
 ----
-Mono<Integer> affectedRows = client.execute()
-        .sql("UPDATE person SET name = 'Joe'")
+Mono<Integer> affectedRows = client.execute("UPDATE person SET name = 'Joe'")
         .fetch().rowsUpdated();
 ----
 
@@ -381,8 +378,7 @@ You might have noticed the use of `fetch()` in the previous example.
 
 [source,java]
 ----
-Mono<Map<String, Object>> first = client.execute()
-        .sql("SELECT id, name FROM person")
+Mono<Map<String, Object>> first = client.execute("SELECT id, name FROM person")
         .fetch().first();
 ----
 
@@ -398,8 +394,7 @@ You can consume data with the following operators:
 
 [source,java]
 ----
-Flux<Person> all = client.execute()
-        .sql("SELECT id, name FROM mytable")
+Flux<Person> all = client.execute("SELECT id, name FROM mytable")
         .as(Person.class)
         .fetch().all();
 ----
@@ -416,8 +411,7 @@ The following example extracts the `id` column and emits its value:
 
 [source,java]
 ----
-Flux<String> names= client.execute()
-        .sql("SELECT name FROM person")
+Flux<String> names= client.execute("SELECT name FROM person")
         .map((row, rowMetadata) -> row.get("id", String.class))
         .all();
 ----
@@ -450,8 +444,7 @@ The following example shows parameter binding for a query:
 
 [source,java]
 ----
-db.execute()
-    .sql("INSERT INTO person (id, name, age) VALUES(:id, :name, :age)")
+db.execute("INSERT INTO person (id, name, age) VALUES(:id, :name, :age)")
     .bind("id", "joe")
     .bind("name", "Joe")
     .bind("age", 34);
@@ -489,8 +482,7 @@ List<Object[]> tuples = new ArrayList<>();
 tuples.add(new Object[] {"John", 35});
 tuples.add(new Object[] {"Ann",  50});
 
-db.execute()
-    .sql("SELECT id, name, state FROM table WHERE (name, age) IN (:tuples)")
+db.execute("SELECT id, name, state FROM table WHERE (name, age) IN (:tuples)")
     .bind("tuples", tuples);
 ----
 
@@ -500,8 +492,7 @@ A simpler variant using `IN` predicates:
 
 [source,java]
 ----
-db.execute()
-    .sql("SELECT id, name, state FROM table WHERE age IN (:ages)")
+db.execute("SELECT id, name, state FROM table WHERE age IN (:ages)")
     .bind("ages", Arrays.asList(35, 50));
 ----
 
@@ -522,12 +513,12 @@ TransactionalDatabaseClient databaseClient = TransactionalDatabaseClient.create(
 
 Flux<Void> completion = databaseClient.inTransaction(db -> {
 
-    return db.execute().sql("INSERT INTO person (id, name, age) VALUES(:id, :name, :age)")
+    return db.execute("INSERT INTO person (id, name, age) VALUES(:id, :name, :age)")
             .bind("id", "joe")
             .bind("name", "Joe")
             .bind("age", 34)
             .fetch().rowsUpdated()
-            .then(db.execute().sql("INSERT INTO contacts (id, name) VALUES(:id, :name)")
+            .then(db.execute("INSERT INTO contacts (id, name) VALUES(:id, :name)")
                     .bind("id", "joe")
                     .bind("name", "Joe")
                     .fetch().rowsUpdated())

--- a/src/main/java/org/springframework/data/r2dbc/function/DatabaseClient.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/DatabaseClient.java
@@ -59,6 +59,38 @@ public interface DatabaseClient {
 	InsertIntoSpec insert();
 
 	/**
+	 * Specify a static {@code sql} string to execute. Contract for specifying a SQL call along with options leading to
+	 * the exchange. The SQL string can contain either native parameter bind markers (e.g. {@literal $1, $2} for Postgres,
+	 * {@literal @P0, @P1} for SQL Server) or named parameters (e.g. {@literal :foo, :bar}) when
+	 * {@link NamedParameterExpander} is enabled.
+	 *
+	 * @see NamedParameterExpander
+	 * @see DatabaseClient.Builder#namedParameters(NamedParameterExpander)
+	 * @param sql must not be {@literal null} or empty.
+	 * @return a new {@link GenericExecuteSpec}.
+	 * @see NamedParameterExpander
+	 * @see DatabaseClient.Builder#namedParameters(NamedParameterExpander)
+	 */
+	GenericExecuteSpec execute(String sql);
+
+	/**
+	 * Specify a {@link Supplier SQL supplier} that provides SQL to execute. Contract for specifying a SQL call along with
+	 * options leading to the exchange. The SQL string can contain either native parameter bind markers (e.g.
+	 * {@literal $1, $2} for Postgres, {@literal @P0, @P1} for SQL Server) or named parameters (e.g.
+	 * {@literal :foo, :bar}) when {@link NamedParameterExpander} is enabled.
+	 * <p>
+	 * Accepts {@link PreparedOperation} as SQL and binding {@link Supplier}.
+	 * </p>
+	 *
+	 * @param sqlSupplier must not be {@literal null}.
+	 * @return a new {@link GenericExecuteSpec}.
+	 * @see NamedParameterExpander
+	 * @see DatabaseClient.Builder#namedParameters(NamedParameterExpander)
+	 * @see PreparedOperation
+	 */
+	GenericExecuteSpec execute(Supplier<String> sqlSupplier);
+
+	/**
 	 * Return a builder to mutate properties of this database client.
 	 */
 	DatabaseClient.Builder mutate();
@@ -145,7 +177,9 @@ public interface DatabaseClient {
 	 *
 	 * @see NamedParameterExpander
 	 * @see DatabaseClient.Builder#namedParameters(NamedParameterExpander)
+	 * @deprecated use {@code DatabaseClient.execute(…)} directly.
 	 */
+	@Deprecated
 	interface SqlSpec {
 
 		/**
@@ -154,6 +188,7 @@ public interface DatabaseClient {
 		 * @param sql must not be {@literal null} or empty.
 		 * @return a new {@link GenericExecuteSpec}.
 		 */
+		@Deprecated
 		GenericExecuteSpec sql(String sql);
 
 		/**
@@ -163,6 +198,7 @@ public interface DatabaseClient {
 		 * @return a new {@link GenericExecuteSpec}.
 		 * @see PreparedOperation
 		 */
+		@Deprecated
 		GenericExecuteSpec sql(Supplier<String> sqlSupplier);
 	}
 

--- a/src/main/java/org/springframework/data/r2dbc/function/DefaultDatabaseClient.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/DefaultDatabaseClient.java
@@ -114,6 +114,22 @@ class DefaultDatabaseClient implements DatabaseClient, ConnectionAccessor {
 		return new DefaultInsertIntoSpec();
 	}
 
+	@Override
+	public GenericExecuteSpec execute(String sql) {
+
+		Assert.hasText(sql, "SQL must not be null or empty!");
+
+		return execute(() -> sql);
+	}
+
+	@Override
+	public GenericExecuteSpec execute(Supplier<String> sqlSupplier) {
+
+		Assert.notNull(sqlSupplier, "SQL Supplier must not be null!");
+
+		return createGenericExecuteSpec(sqlSupplier);
+	}
+
 	/**
 	 * Execute a callback {@link Function} within a {@link Connection} scope. The function is responsible for creating a
 	 * {@link Mono}. The connection is released after the {@link Mono} terminates (or the subscription is cancelled).

--- a/src/main/java/org/springframework/data/r2dbc/function/TransactionalDatabaseClient.java
+++ b/src/main/java/org/springframework/data/r2dbc/function/TransactionalDatabaseClient.java
@@ -40,7 +40,7 @@ import org.springframework.util.Assert;
  * <pre class="code">
  * Flux<Integer> transactionalFlux = databaseClient.inTransaction(db -> {
  *
- * 	return db.execute().sql("INSERT INTO person (id, firstname, lastname) VALUES(:id, :firstname, :lastname)") //
+ * 	return db.execute("INSERT INTO person (id, firstname, lastname) VALUES(:id, :firstname, :lastname)") //
  * 			.bind("id", 1) //
  * 			.bind("firstname", "Walter") //
  * 			.bind("lastname", "White") //
@@ -55,7 +55,7 @@ import org.springframework.util.Assert;
  * <pre class="code">
  * Mono<Void> mono = databaseClient.beginTransaction()
  * 		.then(databaseClient.execute()
- * 				.sql("INSERT INTO person (id, firstname, lastname) VALUES(:id, :firstname, :lastname)") //
+ * 				.execute("INSERT INTO person (id, firstname, lastname) VALUES(:id, :firstname, :lastname)") //
  * 				.bind("id", 1) //
  * 				.bind("firstname", "Walter") //
  * 				.bind("lastname", "White") //

--- a/src/main/java/org/springframework/data/r2dbc/repository/query/AbstractR2dbcQuery.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/query/AbstractR2dbcQuery.java
@@ -103,7 +103,7 @@ public abstract class AbstractR2dbcQuery implements RepositoryQuery {
 		BindableQuery query = createQuery(parameterAccessor);
 
 		ResultProcessor processor = method.getResultProcessor().withDynamicProjection(parameterAccessor);
-		GenericExecuteSpec boundQuery = query.bind(databaseClient.execute().sql(query));
+		GenericExecuteSpec boundQuery = query.bind(databaseClient.execute(query));
 		FetchSpec<?> fetchSpec = boundQuery.as(resolveResultType(processor)).fetch();
 
 		String tableName = method.getEntityInformation().getTableName();

--- a/src/main/java/org/springframework/data/r2dbc/repository/support/SimpleR2dbcRepository.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/support/SimpleR2dbcRepository.java
@@ -85,7 +85,7 @@ public class SimpleR2dbcRepository<T, ID> implements ReactiveCrudRepository<T, I
 			binder.filterBy(idColumnName, SettableValue.from(id));
 		});
 
-		return databaseClient.execute().sql(operation).as(entity.getJavaType()) //
+		return databaseClient.execute(operation).as(entity.getJavaType()) //
 				.then() //
 				.thenReturn(objectToSave);
 	}
@@ -130,7 +130,7 @@ public class SimpleR2dbcRepository<T, ID> implements ReactiveCrudRepository<T, I
 					binder.filterBy(idColumnName, SettableValue.from(id));
 				});
 
-		return databaseClient.execute().sql(operation) //
+		return databaseClient.execute(operation) //
 				.as(entity.getJavaType()) //
 				.fetch() //
 				.one();
@@ -159,7 +159,7 @@ public class SimpleR2dbcRepository<T, ID> implements ReactiveCrudRepository<T, I
 					binder.filterBy(idColumnName, SettableValue.from(id));
 				});
 
-		return databaseClient.execute().sql(operation) //
+		return databaseClient.execute(operation) //
 				.map((r, md) -> r) //
 				.first() //
 				.hasElement();
@@ -214,7 +214,7 @@ public class SimpleR2dbcRepository<T, ID> implements ReactiveCrudRepository<T, I
 						binder.filterBy(idColumnName, SettableValue.from(ids));
 					});
 
-			return databaseClient.execute().sql(operation).as(entity.getJavaType()).fetch().all();
+			return databaseClient.execute(operation).as(entity.getJavaType()).fetch().all();
 		});
 	}
 
@@ -230,7 +230,7 @@ public class SimpleR2dbcRepository<T, ID> implements ReactiveCrudRepository<T, I
 				.from(table) //
 				.build();
 
-		return databaseClient.execute().sql(SqlRenderer.toString(select)) //
+		return databaseClient.execute(SqlRenderer.toString(select)) //
 				.map((r, md) -> r.get(0, Long.class)) //
 				.first() //
 				.defaultIfEmpty(0L);
@@ -249,7 +249,7 @@ public class SimpleR2dbcRepository<T, ID> implements ReactiveCrudRepository<T, I
 			binder.filterBy(getIdColumnName(), SettableValue.from(id));
 		});
 
-		return databaseClient.execute().sql(delete) //
+		return databaseClient.execute(delete) //
 				.fetch() //
 				.rowsUpdated() //
 				.then();
@@ -273,7 +273,7 @@ public class SimpleR2dbcRepository<T, ID> implements ReactiveCrudRepository<T, I
 				binder.filterBy(getIdColumnName(), SettableValue.from(ids));
 			});
 
-			return databaseClient.execute().sql(delete).then();
+			return databaseClient.execute(delete).then();
 		}).then();
 	}
 
@@ -319,7 +319,7 @@ public class SimpleR2dbcRepository<T, ID> implements ReactiveCrudRepository<T, I
 	@Override
 	public Mono<Void> deleteAll() {
 
-		return databaseClient.execute().sql(String.format("DELETE FROM %s", entity.getTableName())) //
+		return databaseClient.execute(String.format("DELETE FROM %s", entity.getTableName())) //
 				.then();
 	}
 

--- a/src/test/java/org/springframework/data/r2dbc/function/AbstractDatabaseClientIntegrationTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/function/AbstractDatabaseClientIntegrationTests.java
@@ -100,7 +100,7 @@ public abstract class AbstractDatabaseClientIntegrationTests extends R2dbcIntegr
 
 		DatabaseClient databaseClient = DatabaseClient.create(connectionFactory);
 
-		databaseClient.execute().sql(getInsertIntoLegosetStatement()) //
+		databaseClient.execute(getInsertIntoLegosetStatement()) //
 				.bind("id", 42055) //
 				.bind("name", "SCHAUFELRADBAGGER") //
 				.bindNull("manual", Integer.class) //
@@ -119,7 +119,7 @@ public abstract class AbstractDatabaseClientIntegrationTests extends R2dbcIntegr
 
 		executeInsert();
 
-		databaseClient.execute().sql(getInsertIntoLegosetStatement()) //
+		databaseClient.execute(getInsertIntoLegosetStatement()) //
 				.bind(0, 42055) //
 				.bind(1, "SCHAUFELRADBAGGER") //
 				.bindNull(2, Integer.class) //
@@ -138,7 +138,7 @@ public abstract class AbstractDatabaseClientIntegrationTests extends R2dbcIntegr
 
 		DatabaseClient databaseClient = DatabaseClient.create(connectionFactory);
 
-		databaseClient.execute().sql("SELECT id, name, manual FROM legoset") //
+		databaseClient.execute("SELECT id, name, manual FROM legoset") //
 				.as(LegoSet.class) //
 				.fetch().all() //
 				.as(StepVerifier::create) //

--- a/src/test/java/org/springframework/data/r2dbc/function/AbstractTransactionalDatabaseClientIntegrationTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/function/AbstractTransactionalDatabaseClientIntegrationTests.java
@@ -108,8 +108,7 @@ public abstract class AbstractTransactionalDatabaseClientIntegrationTests extend
 		TransactionalDatabaseClient databaseClient = TransactionalDatabaseClient.create(connectionFactory);
 
 		Flux<Integer> integerFlux = databaseClient.inTransaction(db -> db //
-				.execute() //
-				.sql(getInsertIntoLegosetStatement()) //
+				.execute(getInsertIntoLegosetStatement()) //
 				.bind(0, 42055) //
 				.bind(1, "SCHAUFELRADBAGGER") //
 				.bindNull(2, Integer.class) //
@@ -128,7 +127,7 @@ public abstract class AbstractTransactionalDatabaseClientIntegrationTests extend
 
 		TransactionalDatabaseClient databaseClient = TransactionalDatabaseClient.create(connectionFactory);
 
-		Mono<Integer> integerFlux = databaseClient.execute().sql(getInsertIntoLegosetStatement()) //
+		Mono<Integer> integerFlux = databaseClient.execute(getInsertIntoLegosetStatement()) //
 				.bind(0, 42055) //
 				.bind(1, "SCHAUFELRADBAGGER") //
 				.bindNull(2, Integer.class) //
@@ -148,8 +147,7 @@ public abstract class AbstractTransactionalDatabaseClientIntegrationTests extend
 		TransactionalDatabaseClient databaseClient = TransactionalDatabaseClient.create(connectionFactory);
 
 		Flux<Long> txId = databaseClient //
-				.execute() //
-				.sql(getCurrentTransactionIdStatement()) //
+				.execute(getCurrentTransactionIdStatement()) //
 				.map((r, md) -> r.get(0, Long.class)) //
 				.all();
 
@@ -187,7 +185,7 @@ public abstract class AbstractTransactionalDatabaseClientIntegrationTests extend
 
 		Flux<Integer> integerFlux = databaseClient.inTransaction(db -> {
 
-			return db.execute().sql(getInsertIntoLegosetStatement()) //
+			return db.execute(getInsertIntoLegosetStatement()) //
 					.bind(0, 42055) //
 					.bind(1, "SCHAUFELRADBAGGER") //
 					.bindNull(2, Integer.class) //
@@ -211,14 +209,13 @@ public abstract class AbstractTransactionalDatabaseClientIntegrationTests extend
 
 			// We have to execute a sql statement first.
 			// Otherwise some databases (MySql) don't have a transaction id.
-			Mono<Integer> insert = db.execute().sql(getInsertIntoLegosetStatement()) //
+			Mono<Integer> insert = db.execute(getInsertIntoLegosetStatement()) //
 					.bind(0, 42055) //
 					.bind(1, "SCHAUFELRADBAGGER") //
 					.bindNull(2, Integer.class) //
 					.fetch().rowsUpdated();
 
-			Flux<Object> txId = db.execute() //
-					.sql(getCurrentTransactionIdStatement()) //
+			Flux<Object> txId = db.execute(getCurrentTransactionIdStatement()) //
 					.map((row, md) -> row.get(0)) //
 					.all();
 


### PR DESCRIPTION
We compressed `client.execute().sql(…)` to `client.execute(…) `to not require the intermediate `execute()` step but rather accept the SQL to execute directly.


Changed to:

```java
databaseClient.execute("CREATE TABLE with_arrays")
		.then();

databaseClient.execute("SELECT id, name, manual FROM legoset")
		.as(LegoSet.class)
		.fetch().all()
```

Previously:

```java
databaseClient.execute().sql("CREATE TABLE with_arrays")
		.then();

databaseClient.execute().sql("SELECT id, name, manual FROM legoset")
		.as(LegoSet.class)
		.fetch().all()
```

---

Related ticket: #89.

/cc @odrotbohm @sdeleuze @schauder @michael-simons