### PR TITLE
Kotlin extensions

### DIFF
--- a/src/main/kotlin/org/springframework/data/r2dbc/core/CriteriaStepExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/r2dbc/core/CriteriaStepExtensions.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.core
+
+import org.springframework.data.r2dbc.query.Criteria
+
+/**
+ * Extension for [Criteria.CriteriaStep.is] providing a
+ * `eq(value)` variant.
+ *
+ * @author Jonas Bark
+ */
+infix fun Criteria.CriteriaStep.isEquals(value: Any): Criteria =
+		`is`(value)
+
+/**
+ * Extension for [Criteria.CriteriaStep.in] providing a
+ * `isIn(value)` variant.
+ *
+ * @author Jonas Bark
+ */
+fun Criteria.CriteriaStep.isIn(vararg value: Any): Criteria =
+		`in`(value)
+
+
+/**
+ * Extension for [Criteria.CriteriaStep.in] providing a
+ * `isIn(value)` variant.
+ *
+ * @author Jonas Bark
+ */
+fun Criteria.CriteriaStep.isIn(values: Collection<Any>): Criteria =
+		`in`(values)

--- a/src/main/kotlin/org/springframework/data/r2dbc/core/DatabaseClientExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/r2dbc/core/DatabaseClientExtensions.kt
@@ -16,6 +16,7 @@
 package org.springframework.data.r2dbc.core
 
 import kotlinx.coroutines.reactive.awaitFirstOrNull
+import org.springframework.data.r2dbc.query.Criteria
 
 /**
  * Coroutines variant of [DatabaseClient.GenericExecuteSpec.then].
@@ -80,3 +81,20 @@ suspend fun <T> DatabaseClient.InsertSpec<T>.await() {
 inline fun <reified T : Any> DatabaseClient.InsertIntoSpec.into(): DatabaseClient.TypedInsertSpec<T> =
 		into(T::class.java)
 
+/**
+ * Extension for [DatabaseClient.SelectFromSpec.from] providing a
+ * `from<Foo>()` variant.
+ *
+ * @author Jonas Bark
+ */
+inline fun <reified T : Any> DatabaseClient.SelectFromSpec.from(): DatabaseClient.TypedSelectSpec<T> =
+		from(T::class.java)
+
+/**
+ * Extension for [DatabaseClient.SelectFromSpec.from] providing a
+ * `from<Foo>()` variant.
+ *
+ * @author Jonas Bark
+ */
+inline fun <reified T : Any> DatabaseClient.DeleteFromSpec.from(): DatabaseClient.TypedDeleteSpec<T> =
+		from(T::class.java)

--- a/src/test/kotlin/org/springframework/data/r2dbc/core/CriteriaStepExtensionsTests.kt
+++ b/src/test/kotlin/org/springframework/data/r2dbc/core/CriteriaStepExtensionsTests.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.core
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.springframework.data.r2dbc.query.Criteria
+import reactor.core.publisher.Mono
+
+/**
+ * Unit tests for [Criteria.CriteriaStep] extensions.
+ *
+ * @author Jonas Bark
+ */
+class CriteriaStepExtensionsTests {
+
+	@Test // gh-63
+	fun eqIsCriteriaStep() {
+
+		val spec = mockk<Criteria.CriteriaStep>()
+		val eqSpec = mockk<Criteria>()
+
+		every { spec.`is`("test") } returns eqSpec
+
+		runBlocking {
+			assertThat(spec isEquals "test").isEqualTo(eqSpec)
+		}
+
+		verify {
+			spec.`is`("test")
+		}
+	}
+}

--- a/src/test/kotlin/org/springframework/data/r2dbc/core/CriteriaStepExtensionsTests.kt
+++ b/src/test/kotlin/org/springframework/data/r2dbc/core/CriteriaStepExtensionsTests.kt
@@ -32,7 +32,7 @@ import reactor.core.publisher.Mono
  */
 class CriteriaStepExtensionsTests {
 
-	@Test // gh-63
+	@Test // gh-122
 	fun eqIsCriteriaStep() {
 
 		val spec = mockk<Criteria.CriteriaStep>()

--- a/src/test/kotlin/org/springframework/data/r2dbc/core/DatabaseClientExtensionsTests.kt
+++ b/src/test/kotlin/org/springframework/data/r2dbc/core/DatabaseClientExtensionsTests.kt
@@ -141,7 +141,7 @@ class DatabaseClientExtensionsTests {
 		}
 	}
 
-	@Test // gh-63
+	@Test // gh-122
 	fun selectFromSpecInto() {
 
 		val spec = mockk<DatabaseClient.SelectFromSpec>()
@@ -157,7 +157,7 @@ class DatabaseClientExtensionsTests {
 		}
 	}
 
-	@Test // gh-63
+	@Test // gh-122
 	fun deleteFromSpecInto() {
 
 		val spec = mockk<DatabaseClient.DeleteFromSpec>()

--- a/src/test/kotlin/org/springframework/data/r2dbc/core/DatabaseClientExtensionsTests.kt
+++ b/src/test/kotlin/org/springframework/data/r2dbc/core/DatabaseClientExtensionsTests.kt
@@ -17,16 +17,19 @@ package org.springframework.data.r2dbc.core
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import org.springframework.data.r2dbc.query.Criteria
 import reactor.core.publisher.Mono
 
 /**
  * Unit tests for [DatabaseClient] extensions.
  *
  * @author Sebastien Deleuze
+ * @author Jonas Bark
  */
 class DatabaseClientExtensionsTests {
 
@@ -135,6 +138,38 @@ class DatabaseClientExtensionsTests {
 
 		verify {
 			spec.into(String::class.java)
+		}
+	}
+
+	@Test // gh-63
+	fun selectFromSpecInto() {
+
+		val spec = mockk<DatabaseClient.SelectFromSpec>()
+		val typedSpec: DatabaseClient.TypedSelectSpec<String> = mockk()
+		every { spec.from(String::class.java) } returns typedSpec
+
+		runBlocking {
+			assertThat(spec.from<String>()).isEqualTo(typedSpec)
+		}
+
+		verify {
+			spec.from(String::class.java)
+		}
+	}
+
+	@Test // gh-63
+	fun deleteFromSpecInto() {
+
+		val spec = mockk<DatabaseClient.DeleteFromSpec>()
+		val typedSpec: DatabaseClient.TypedDeleteSpec<String> = mockk()
+		every { spec.from(String::class.java) } returns typedSpec
+
+		runBlocking {
+			assertThat(spec.from<String>()).isEqualTo(typedSpec)
+		}
+
+		verify {
+			spec.from(String::class.java)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #122 

This enabled nicer syntax like this: 
`client.delete().from<User>()` instead of
`client.delete().from(User::class.java)`