### PR TITLE
#209 - Provide extensions on TypedExecuteSpec and GenericExecuteSpec.

### DIFF
--- a/src/main/kotlin/org/springframework/data/r2dbc/core/DatabaseClientExtensions.kt
+++ b/src/main/kotlin/org/springframework/data/r2dbc/core/DatabaseClientExtensions.kt
@@ -31,17 +31,37 @@ suspend fun DatabaseClient.GenericExecuteSpec.await() {
  * Extension for [DatabaseClient.BindSpec.bind] providing a variant leveraging reified type parameters
  *
  * @author Mark Paluch
+ * @author Ibanga Enoobong Ime
  */
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
-inline fun <reified T : Any> DatabaseClient.BindSpec<*>.bind(index: Int, value: T?) = bind(index, SettableValue.fromOrEmpty(value, T::class.java))
+inline fun <reified T : Any> DatabaseClient.TypedExecuteSpec<*>.bind(index: Int, value: T?) = bind(index, SettableValue.fromOrEmpty(value, T::class.java))
 
 /**
  * Extension for [DatabaseClient.BindSpec.bind] providing a variant leveraging reified type parameters
  *
  * @author Mark Paluch
+ * @author Ibanga Enoobong Ime
  */
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER")
-inline fun <reified T : Any> DatabaseClient.BindSpec<*>.bind(name: String, value: T?) = bind(name, SettableValue.fromOrEmpty(value, T::class.java))
+inline fun <reified T : Any> DatabaseClient.GenericExecuteSpec.bind(index: Int, value: T?) = bind(index, SettableValue.fromOrEmpty(value, T::class.java))
+
+/**
+ * Extension for [DatabaseClient.BindSpec.bind] providing a variant leveraging reified type parameters
+ *
+ * @author Mark Paluch
+ * @author Ibanga Enoobong Ime
+ */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+inline fun <reified T : Any> DatabaseClient.TypedExecuteSpec<*>.bind(name: String, value: T?) = bind(name, SettableValue.fromOrEmpty(value, T::class.java))
+
+/**
+ * Extension for [DatabaseClient.BindSpec.bind] providing a variant leveraging reified type parameters
+ *
+ * @author Mark Paluch
+ * @author Ibanga Enoobong Ime
+ */
+@Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+inline fun <reified T : Any> DatabaseClient.GenericExecuteSpec.bind(name: String, value: T?) = bind(name, SettableValue.fromOrEmpty(value, T::class.java))
 
 /**
  * Extension for [DatabaseClient.GenericExecuteSpec. as] providing a

--- a/src/test/kotlin/org/springframework/data/r2dbc/core/DatabaseClientExtensionsTests.kt
+++ b/src/test/kotlin/org/springframework/data/r2dbc/core/DatabaseClientExtensionsTests.kt
@@ -48,6 +48,21 @@ class DatabaseClientExtensionsTests {
 		}
 	}
 
+	@Test // gh-209
+	fun typedExecuteSpecBindByIndexShouldBindValue() {
+
+		val spec = mockk<DatabaseClient.TypedExecuteSpec<String>>()
+		every { spec.bind(eq(0), any()) } returns spec
+
+		runBlocking {
+			spec.bind<String>(0, "foo")
+		}
+
+		verify {
+			spec.bind(0, SettableValue.fromOrEmpty("foo", String::class.java))
+		}
+	}
+
 	@Test // gh-162
 	fun bindByIndexShouldBindNull() {
 
@@ -63,10 +78,40 @@ class DatabaseClientExtensionsTests {
 		}
 	}
 
+	@Test // gh-209
+	fun typedExecuteSpecBindByIndexShouldBindNull() {
+
+		val spec = mockk<DatabaseClient.TypedExecuteSpec<String>>()
+		every { spec.bind(eq(0), any()) } returns spec
+
+		runBlocking {
+			spec.bind<String>(0, null)
+		}
+
+		verify {
+			spec.bind(0, SettableValue.empty(String::class.java))
+		}
+	}
+
 	@Test // gh-162
 	fun bindByNameShouldBindValue() {
 
 		val spec = mockk<DatabaseClient.GenericExecuteSpec>()
+		every { spec.bind(eq("field"), any()) } returns spec
+
+		runBlocking {
+			spec.bind<String>("field", "foo")
+		}
+
+		verify {
+			spec.bind("field", SettableValue.fromOrEmpty("foo", String::class.java))
+		}
+	}
+
+	@Test // gh-162
+	fun typedExecuteSpecBindByNameShouldBindValue() {
+
+		val spec = mockk<DatabaseClient.TypedExecuteSpec<String>>()
 		every { spec.bind(eq("field"), any()) } returns spec
 
 		runBlocking {


### PR DESCRIPTION
The original extensions did not allow for executing fetch operations because they where on BindSpec.

This allows for that

cc @sdeleuze 