### PR TITLE
Add support for Criteria composition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>1.1.0.BUILD-SNAPSHOT</version>
+	<version>1.1.0.gh-289-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC</description>
@@ -22,7 +24,7 @@
 		<dist.key>DATAR2DBC</dist.key>
 
 		<springdata.commons>2.3.0.BUILD-SNAPSHOT</springdata.commons>
-		<springdata.jdbc>2.0.0.BUILD-SNAPSHOT</springdata.jdbc>
+		<springdata.jdbc>2.0.0.DATAJDBC-490-SNAPSHOT</springdata.jdbc>
 		<springdata.relational>${springdata.jdbc}</springdata.relational>
 		<java-module-name>spring.data.r2dbc</java-module-name>
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>

--- a/src/main/java/org/springframework/data/r2dbc/core/DefaultStatementMapper.java
+++ b/src/main/java/org/springframework/data/r2dbc/core/DefaultStatementMapper.java
@@ -88,7 +88,7 @@ class DefaultStatementMapper implements StatementMapper {
 		BindMarkers bindMarkers = this.dialect.getBindMarkersFactory().create();
 		Bindings bindings = Bindings.empty();
 
-		if (selectSpec.getCriteria() != null) {
+		if (!selectSpec.getCriteria().isEmpty()) {
 
 			BoundCondition mappedObject = this.updateMapper.getMappedObject(bindMarkers, selectSpec.getCriteria(), table,
 					entity);
@@ -203,7 +203,7 @@ class DefaultStatementMapper implements StatementMapper {
 
 		Update update;
 
-		if (updateSpec.getCriteria() != null) {
+		if (!updateSpec.getCriteria().isEmpty()) {
 
 			BoundCondition boundCondition = this.updateMapper.getMappedObject(bindMarkers, updateSpec.getCriteria(), table,
 					entity);
@@ -237,7 +237,7 @@ class DefaultStatementMapper implements StatementMapper {
 		Bindings bindings = Bindings.empty();
 
 		Delete delete;
-		if (deleteSpec.getCriteria() != null) {
+		if (!deleteSpec.getCriteria().isEmpty()) {
 
 			BoundCondition boundCondition = this.updateMapper.getMappedObject(bindMarkers, deleteSpec.getCriteria(), table,
 					entity);

--- a/src/main/java/org/springframework/data/r2dbc/core/StatementMapper.java
+++ b/src/main/java/org/springframework/data/r2dbc/core/StatementMapper.java
@@ -185,7 +185,7 @@ public interface StatementMapper {
 		private final Table table;
 		private final List<String> projectedFields;
 		private final List<Expression> selectList;
-		private final @Nullable Criteria criteria;
+		private final Criteria criteria;
 		private final Sort sort;
 		private final long offset;
 		private final int limit;
@@ -219,7 +219,7 @@ public interface StatementMapper {
 		 * @since 1.1
 		 */
 		public static SelectSpec create(SqlIdentifier table) {
-			return new SelectSpec(Table.create(table), Collections.emptyList(), Collections.emptyList(), null,
+			return new SelectSpec(Table.create(table), Collections.emptyList(), Collections.emptyList(), Criteria.empty(),
 					Sort.unsorted(), -1, -1);
 		}
 
@@ -463,9 +463,9 @@ public interface StatementMapper {
 		@Nullable
 		private final Update update;
 
-		private final @Nullable Criteria criteria;
+		private final Criteria criteria;
 
-		protected UpdateSpec(SqlIdentifier table, @Nullable Update update, @Nullable Criteria criteria) {
+		protected UpdateSpec(SqlIdentifier table, @Nullable Update update, Criteria criteria) {
 
 			this.table = table;
 			this.update = update;
@@ -490,7 +490,7 @@ public interface StatementMapper {
 		 * @since 1.1
 		 */
 		public static UpdateSpec create(SqlIdentifier table, Update update) {
-			return new UpdateSpec(table, update, null);
+			return new UpdateSpec(table, update, Criteria.empty());
 		}
 
 		/**
@@ -512,7 +512,6 @@ public interface StatementMapper {
 			return this.update;
 		}
 
-		@Nullable
 		public Criteria getCriteria() {
 			return this.criteria;
 		}
@@ -525,9 +524,9 @@ public interface StatementMapper {
 
 		private final SqlIdentifier table;
 
-		private final @Nullable Criteria criteria;
+		private final Criteria criteria;
 
-		protected DeleteSpec(SqlIdentifier table, @Nullable Criteria criteria) {
+		protected DeleteSpec(SqlIdentifier table, Criteria criteria) {
 			this.table = table;
 			this.criteria = criteria;
 		}
@@ -550,7 +549,7 @@ public interface StatementMapper {
 		 * @since 1.1
 		 */
 		public static DeleteSpec create(SqlIdentifier table) {
-			return new DeleteSpec(table, null);
+			return new DeleteSpec(table, Criteria.empty());
 		}
 
 		/**
@@ -567,7 +566,6 @@ public interface StatementMapper {
 			return this.table;
 		}
 
-		@Nullable
 		public Criteria getCriteria() {
 			return this.criteria;
 		}


### PR DESCRIPTION
We now support composition of `Criteria` objects to create a `Criteria` from one or more top-level criteria and to compose nested AND/OR Criteria objects:

```java
Criteria.where("name").is("Foo")).and(
        Criteria.where("name").is("Bar").or("age").lessThan(49).or(
                Criteria.where("name").not("Bar").and("age").greaterThan(49))
```

---

Related ticket: #289.
Depends on spring-projects/spring-data-jdbc#193