### PR TITLE
#189 - Accept StatementFilterFunction in DatabaseClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>1.1.0.BUILD-SNAPSHOT</version>
+	<version>1.1.0.gh-189-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC</description>

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -5,7 +5,8 @@
 == What's New in Spring Data R2DBC 1.1.0 RELEASE
 
 * Introduction of `R2dbcEntityTemplate` for entity-oriented operations.
-* Support interface projections with `DatabaseClient.as(…)`
+* Support interface projections with `DatabaseClient.as(…)`.
+* <<r2dbc.datbaseclient.filter,Support for `ExecuteFunction` and `StatementFilterFunction` via `DatabaseClient.filter(…)`>>.
 
 [[new-features.1-0-0-RELEASE]]
 == What's New in Spring Data R2DBC 1.0.0 RELEASE

--- a/src/main/asciidoc/reference/r2dbc-sql.adoc
+++ b/src/main/asciidoc/reference/r2dbc-sql.adoc
@@ -134,7 +134,7 @@ In JDBC, the actual drivers translate `?` bind markers to database-native marker
 
 Spring Data R2DBC lets you use native bind markers or named bind markers with the `:name` syntax.
 
-Named parameter support leverages a `R2dbcDialect` instance  to expand named parameters to native bind markers at the time of query execution, which gives you a certain degree of query portability across various database vendors.
+Named parameter support leverages a `R2dbcDialect` instance to expand named parameters to native bind markers at the time of query execution, which gives you a certain degree of query portability across various database vendors.
 ****
 
 The query-preprocessor unrolls named `Collection` parameters into a series of bind markers to remove the need of dynamic query creation based on the number of arguments.
@@ -159,7 +159,7 @@ tuples.add(new Object[] {"John", 35});
 tuples.add(new Object[] {"Ann",  50});
 
 db.execute("SELECT id, name, state FROM table WHERE (name, age) IN (:tuples)")
-    .bind("tuples", tuples);
+    .bind("tuples", tuples)
 ----
 ====
 
@@ -171,6 +171,38 @@ The following example shows a simpler variant using `IN` predicates:
 [source,java]
 ----
 db.execute("SELECT id, name, state FROM table WHERE age IN (:ages)")
-    .bind("ages", Arrays.asList(35, 50));
+    .bind("ages", Arrays.asList(35, 50))
 ----
 ====
+
+[[r2dbc.datbaseclient.filter]]
+== Statement Filters
+
+You can register a `Statement` filter (`StatementFilterFunction`) through `DatabaseClient` to intercept and modify statements in their execution, as the following example shows:
+
+====
+[source,java]
+----
+db.execute("INSERT INTO table (name, state) VALUES(:name, :state)")
+    .filter((s, next) -> next.execute(s.returnGeneratedValues("id")))
+    .bind("name", …)
+    .bind("state", …)
+----
+====
+
+`DatabaseClient` exposes also simplified `filter(…)` overload accepting `UnaryOperator<Statement>`:
+
+====
+[source,java]
+----
+db.execute("INSERT INTO table (name, state) VALUES(:name, :state)")
+    .filter(s -> s.returnGeneratedValues("id"))
+    .bind("name", …)
+    .bind("state", …)
+
+db.execute("SELECT id, name, state FROM table")
+    .filter(s -> s.fetchSize(25))
+----
+====
+
+`StatementFilterFunction` allow filtering of the executed `Statement` and filtering of `Result` objects.

--- a/src/main/java/org/springframework/data/r2dbc/core/DatabaseClient.java
+++ b/src/main/java/org/springframework/data/r2dbc/core/DatabaseClient.java
@@ -27,7 +27,6 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
 
 import org.reactivestreams.Publisher;
 
@@ -892,7 +891,7 @@ public interface DatabaseClient {
 		 *
 		 * @param filter the filter to be added to the chain.
 		 */
-		default S filter(UnaryOperator<Statement> filter) {
+		default S filter(Function<? super Statement, ? extends Statement> filter) {
 
 			Assert.notNull(filter, "Statement FilterFunction must not be null!");
 

--- a/src/main/java/org/springframework/data/r2dbc/core/DefaultDatabaseClient.java
+++ b/src/main/java/org/springframework/data/r2dbc/core/DefaultDatabaseClient.java
@@ -343,6 +343,7 @@ class DefaultDatabaseClient implements DatabaseClient, ConnectionAccessor {
 
 		ExecuteSpecSupport(Map<Integer, SettableValue> byIndex, Map<String, SettableValue> byName,
 				Supplier<String> sqlSupplier, StatementFilterFunction filterFunction) {
+
 			this.byIndex = byIndex;
 			this.byName = byName;
 			this.sqlSupplier = sqlSupplier;

--- a/src/main/java/org/springframework/data/r2dbc/core/DefaultDatabaseClientBuilder.java
+++ b/src/main/java/org/springframework/data/r2dbc/core/DefaultDatabaseClientBuilder.java
@@ -17,6 +17,7 @@
 package org.springframework.data.r2dbc.core;
 
 import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.Statement;
 
 import java.util.function.Consumer;
 
@@ -40,6 +41,8 @@ class DefaultDatabaseClientBuilder implements DatabaseClient.Builder {
 
 	private @Nullable R2dbcExceptionTranslator exceptionTranslator;
 
+	private ExecuteFunction executeFunction = Statement::execute;
+
 	private ReactiveDataAccessStrategy accessStrategy;
 
 	private boolean namedParameters = true;
@@ -54,6 +57,7 @@ class DefaultDatabaseClientBuilder implements DatabaseClient.Builder {
 
 		this.connectionFactory = other.connectionFactory;
 		this.exceptionTranslator = other.exceptionTranslator;
+		this.executeFunction = other.executeFunction;
 		this.accessStrategy = other.accessStrategy;
 		this.namedParameters = other.namedParameters;
 		this.projectionFactory = other.projectionFactory;
@@ -82,6 +86,19 @@ class DefaultDatabaseClientBuilder implements DatabaseClient.Builder {
 		Assert.notNull(exceptionTranslator, "R2dbcExceptionTranslator must not be null!");
 
 		this.exceptionTranslator = exceptionTranslator;
+		return this;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.r2dbc.function.DatabaseClient.Builder#executeFunction(org.springframework.data.r2dbc.core.ExecuteFunction)
+	 */
+	@Override
+	public Builder executeFunction(ExecuteFunction executeFunction) {
+
+		Assert.notNull(executeFunction, "ExecuteFunction must not be null!");
+
+		this.executeFunction = executeFunction;
 		return this;
 	}
 
@@ -143,8 +160,8 @@ class DefaultDatabaseClientBuilder implements DatabaseClient.Builder {
 			accessStrategy = new DefaultReactiveDataAccessStrategy(dialect);
 		}
 
-		return new DefaultDatabaseClient(this.connectionFactory, exceptionTranslator, accessStrategy, namedParameters,
-				projectionFactory, new DefaultDatabaseClientBuilder(this));
+		return new DefaultDatabaseClient(this.connectionFactory, exceptionTranslator, executeFunction, accessStrategy,
+				namedParameters, projectionFactory, new DefaultDatabaseClientBuilder(this));
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/r2dbc/core/ExecuteFunction.java
+++ b/src/main/java/org/springframework/data/r2dbc/core/ExecuteFunction.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.core;
+
+import io.r2dbc.spi.Result;
+import io.r2dbc.spi.Statement;
+
+import java.util.function.BiFunction;
+
+import org.reactivestreams.Publisher;
+
+/**
+ * Represents a function that executes a {@link io.r2dbc.spi.Statement} for a (delayed) {@link io.r2dbc.spi.Result}
+ * stream.
+ * <p>
+ * Note that discarded {@link Result} objects must be consumed according to the R2DBC spec via either
+ * {@link Result#getRowsUpdated()} or {@link Result#map(BiFunction)}.
+ *
+ * @author Mark Paluch
+ * @since 1.1
+ * @see Statement#execute()
+ */
+@FunctionalInterface
+public interface ExecuteFunction {
+
+	/**
+	 * Execute the given {@link Statement} for a stream of {@link Result}s.
+	 *
+	 * @param statement the request to execute.
+	 * @return the delayed result stream.
+	 */
+	Publisher<? extends Result> execute(Statement statement);
+}

--- a/src/main/java/org/springframework/data/r2dbc/core/StatementFilterFunction.java
+++ b/src/main/java/org/springframework/data/r2dbc/core/StatementFilterFunction.java
@@ -61,5 +61,4 @@ public interface StatementFilterFunction {
 
 		return (request, next) -> filter(request, afterRequest -> afterFilter.filter(afterRequest, next));
 	}
-
 }

--- a/src/main/java/org/springframework/data/r2dbc/core/StatementFilterFunction.java
+++ b/src/main/java/org/springframework/data/r2dbc/core/StatementFilterFunction.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.core;
+
+import io.r2dbc.spi.Result;
+import io.r2dbc.spi.Statement;
+
+import org.reactivestreams.Publisher;
+
+import org.springframework.util.Assert;
+
+/**
+ * Represents a function that filters an {@link ExecuteFunction execute function}.
+ * <p>
+ * The filter is executed when a {@link org.reactivestreams.Subscriber} subscribes to the {@link Publisher} returned by
+ * the {@link DatabaseClient}.
+ *
+ * @author Mark Paluch
+ * @since 1.1
+ * @see ExecuteFunction
+ */
+@FunctionalInterface
+public interface StatementFilterFunction {
+
+	/**
+	 * Apply this filter to the given {@link Statement} and {@link ExecuteFunction}.
+	 * <p>
+	 * The given {@link ExecuteFunction} represents the next entity in the chain, to be invoked via
+	 * {@link ExecuteFunction#execute(Statement)} invoked} in order to proceed with the exchange, or not invoked to
+	 * shortcut the chain.
+	 *
+	 * @param statement the current {@link Statement}.
+	 * @param next the next exchange function in the chain.
+	 * @return the filtered {@link Result}s.
+	 */
+	Publisher<? extends Result> filter(Statement statement, ExecuteFunction next);
+
+	/**
+	 * Return a composed filter function that first applies this filter, and then applies the given {@code "after"}
+	 * filter.
+	 *
+	 * @param afterFilter the filter to apply after this filter.
+	 * @return the composed filter.
+	 */
+	default StatementFilterFunction andThen(StatementFilterFunction afterFilter) {
+
+		Assert.notNull(afterFilter, "StatementFilterFunction must not be null");
+
+		return (request, next) -> filter(request, afterRequest -> afterFilter.filter(afterRequest, next));
+	}
+
+}

--- a/src/main/java/org/springframework/data/r2dbc/core/StatementFilterFunctions.java
+++ b/src/main/java/org/springframework/data/r2dbc/core/StatementFilterFunctions.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.core;
+
+import io.r2dbc.spi.Result;
+import io.r2dbc.spi.Statement;
+
+import org.reactivestreams.Publisher;
+
+/**
+ * Collection of default {@link StatementFilterFunction}s.
+ *
+ * @author Mark Paluch
+ * @since 1.1
+ */
+enum StatementFilterFunctions implements StatementFilterFunction {
+
+	EMPTY_FILTER;
+
+	@Override
+	public Publisher<? extends Result> filter(Statement statement, ExecuteFunction next) {
+		return next.execute(statement);
+	}
+
+	/**
+	 * Return an empty {@link StatementFilterFunction} that delegates to {@link ExecuteFunction}.
+	 *
+	 * @return an empty {@link StatementFilterFunction} that delegates to {@link ExecuteFunction}.
+	 */
+	public static StatementFilterFunction empty() {
+		return EMPTY_FILTER;
+	}
+}

--- a/src/test/java/org/springframework/data/r2dbc/core/DefaultDatabaseClientUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/core/DefaultDatabaseClientUnitTests.java
@@ -492,7 +492,7 @@ public class DefaultDatabaseClientUnitTests {
 				.as(StepVerifier::create) //
 				.expectNextCount(1).verifyComplete();
 
-		verify(statement, never()).execute();
+		verifyNoInteractions(statement);
 	}
 
 	@Test // gh-189
@@ -524,6 +524,7 @@ public class DefaultDatabaseClientUnitTests {
 		inOrder.verify(statement).returnGeneratedValues("foo");
 		inOrder.verify(statement).returnGeneratedValues("bar");
 		inOrder.verify(statement).execute();
+		inOrder.verifyNoMoreInteractions();
 	}
 
 	@Test // gh-189
@@ -551,7 +552,10 @@ public class DefaultDatabaseClientUnitTests {
 				.as(StepVerifier::create) //
 				.verifyComplete();
 
-		verify(statement).returnGeneratedValues("foo");
+		InOrder inOrder = inOrder(statement);
+		inOrder.verify(statement).returnGeneratedValues("foo");
+		inOrder.verify(statement).execute();
+		inOrder.verifyNoMoreInteractions();
 	}
 
 	@Test // gh-189
@@ -583,6 +587,7 @@ public class DefaultDatabaseClientUnitTests {
 		inOrder.verify(statement).returnGeneratedValues("foo");
 		inOrder.verify(statement).returnGeneratedValues("bar");
 		inOrder.verify(statement).execute();
+		inOrder.verifyNoMoreInteractions();
 	}
 
 	static class Person {

--- a/src/test/java/org/springframework/data/r2dbc/core/DefaultDatabaseClientUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/core/DefaultDatabaseClientUnitTests.java
@@ -39,47 +39,49 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscription;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.r2dbc.dialect.PostgresDialect;
 import org.springframework.data.r2dbc.mapping.SettableValue;
-import org.springframework.data.r2dbc.support.R2dbcExceptionTranslator;
+import org.springframework.lang.Nullable;
 
 /**
  * Unit tests for {@link DefaultDatabaseClient}.
  *
  * @author Mark Paluch
  * @author Ferdinand Jacobs
+ * @author Jens Schauder
  */
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultDatabaseClientUnitTests {
 
-	@Mock ConnectionFactory connectionFactory;
 	@Mock Connection connection;
-	@Mock R2dbcExceptionTranslator translator;
+	private DatabaseClient.Builder databaseClientBuilder;
 
 	@Before
 	public void before() {
+
+		ConnectionFactory connectionFactory = Mockito.mock(ConnectionFactory.class);
+
 		when(connectionFactory.create()).thenReturn((Publisher) Mono.just(connection));
 		when(connection.close()).thenReturn(Mono.empty());
+
+		databaseClientBuilder = DatabaseClient.builder() //
+				.connectionFactory(connectionFactory) //
+				.dataAccessStrategy(new DefaultReactiveDataAccessStrategy(PostgresDialect.INSTANCE));
 	}
 
 	@Test // gh-48
 	public void shouldCloseConnectionOnlyOnce() {
 
-		DefaultDatabaseClient databaseClient = (DefaultDatabaseClient) DatabaseClient.builder()
-				.connectionFactory(connectionFactory)
-				.dataAccessStrategy(new DefaultReactiveDataAccessStrategy(PostgresDialect.INSTANCE))
-				.exceptionTranslator(translator).build();
+		DefaultDatabaseClient databaseClient = (DefaultDatabaseClient) databaseClientBuilder.build();
 
-		Flux<Object> flux = databaseClient.inConnectionMany(it -> {
-			return Flux.empty();
-		});
+		Flux<Object> flux = databaseClient.inConnectionMany(it -> Flux.empty());
 
 		flux.subscribe(new CoreSubscriber<Object>() {
 			Subscription subscription;
@@ -108,13 +110,9 @@ public class DefaultDatabaseClientUnitTests {
 	@Test // gh-128
 	public void executeShouldBindNullValues() {
 
-		Statement statement = mock(Statement.class);
-		when(connection.createStatement("SELECT * FROM table WHERE key = $1")).thenReturn(statement);
-		when(statement.execute()).thenReturn(Mono.empty());
+		Statement statement = mockStatementFor("SELECT * FROM table WHERE key = $1");
 
-		DefaultDatabaseClient databaseClient = (DefaultDatabaseClient) DatabaseClient.builder()
-				.connectionFactory(connectionFactory)
-				.dataAccessStrategy(new DefaultReactiveDataAccessStrategy(PostgresDialect.INSTANCE)).build();
+		DatabaseClient databaseClient = databaseClientBuilder.build();
 
 		databaseClient.execute("SELECT * FROM table WHERE key = $1") //
 				.bindNull(0, String.class) //
@@ -136,13 +134,9 @@ public class DefaultDatabaseClientUnitTests {
 	@Test // gh-162
 	public void executeShouldBindSettableValues() {
 
-		Statement statement = mock(Statement.class);
-		when(connection.createStatement("SELECT * FROM table WHERE key = $1")).thenReturn(statement);
-		when(statement.execute()).thenReturn(Mono.empty());
+		Statement statement = mockStatementFor("SELECT * FROM table WHERE key = $1");
 
-		DefaultDatabaseClient databaseClient = (DefaultDatabaseClient) DatabaseClient.builder()
-				.connectionFactory(connectionFactory)
-				.dataAccessStrategy(new DefaultReactiveDataAccessStrategy(PostgresDialect.INSTANCE)).build();
+		DatabaseClient databaseClient = databaseClientBuilder.build();
 
 		databaseClient.execute("SELECT * FROM table WHERE key = $1") //
 				.bind(0, SettableValue.empty(String.class)) //
@@ -164,13 +158,8 @@ public class DefaultDatabaseClientUnitTests {
 	@Test // gh-128
 	public void executeShouldBindNamedNullValues() {
 
-		Statement statement = mock(Statement.class);
-		when(connection.createStatement("SELECT * FROM table WHERE key = $1")).thenReturn(statement);
-		when(statement.execute()).thenReturn(Mono.empty());
-
-		DefaultDatabaseClient databaseClient = (DefaultDatabaseClient) DatabaseClient.builder()
-				.connectionFactory(connectionFactory)
-				.dataAccessStrategy(new DefaultReactiveDataAccessStrategy(PostgresDialect.INSTANCE)).build();
+		Statement statement = mockStatementFor("SELECT * FROM table WHERE key = $1");
+		DatabaseClient databaseClient = databaseClientBuilder.build();
 
 		databaseClient.execute("SELECT * FROM table WHERE key = :key") //
 				.bindNull("key", String.class) //
@@ -184,14 +173,9 @@ public class DefaultDatabaseClientUnitTests {
 	@Test // gh-178
 	public void executeShouldBindNamedValuesFromIndexes() {
 
-		Statement statement = mock(Statement.class);
-		when(connection.createStatement("SELECT id, name, manual FROM legoset WHERE name IN ($1, $2, $3)"))
-				.thenReturn(statement);
-		when(statement.execute()).thenReturn(Mono.empty());
+		Statement statement = mockStatementFor("SELECT id, name, manual FROM legoset WHERE name IN ($1, $2, $3)");
 
-		DefaultDatabaseClient databaseClient = (DefaultDatabaseClient) DatabaseClient.builder()
-				.connectionFactory(connectionFactory)
-				.dataAccessStrategy(new DefaultReactiveDataAccessStrategy(PostgresDialect.INSTANCE)).build();
+		DatabaseClient databaseClient = databaseClientBuilder.build();
 
 		databaseClient.execute("SELECT id, name, manual FROM legoset WHERE name IN (:name)") //
 				.bind(0, Arrays.asList("unknown", "dunno", "other")) //
@@ -209,13 +193,9 @@ public class DefaultDatabaseClientUnitTests {
 	@Test // gh-128, gh-162
 	public void executeShouldBindValues() {
 
-		Statement statement = mock(Statement.class);
-		when(connection.createStatement("SELECT * FROM table WHERE key = $1")).thenReturn(statement);
-		when(statement.execute()).thenReturn(Mono.empty());
+		Statement statement = mockStatementFor("SELECT * FROM table WHERE key = $1");
 
-		DefaultDatabaseClient databaseClient = (DefaultDatabaseClient) DatabaseClient.builder()
-				.connectionFactory(connectionFactory)
-				.dataAccessStrategy(new DefaultReactiveDataAccessStrategy(PostgresDialect.INSTANCE)).build();
+		DatabaseClient databaseClient = databaseClientBuilder.build();
 
 		databaseClient.execute("SELECT * FROM table WHERE key = $1") //
 				.bind(0, SettableValue.from("foo")) //
@@ -237,14 +217,8 @@ public class DefaultDatabaseClientUnitTests {
 	@Test // gh-162
 	public void insertShouldAcceptNullValues() {
 
-		Statement statement = mock(Statement.class);
-		when(connection.createStatement("INSERT INTO foo (first, second) VALUES ($1, $2)")).thenReturn(statement);
-		when(statement.returnGeneratedValues()).thenReturn(statement);
-		when(statement.execute()).thenReturn(Mono.empty());
-
-		DefaultDatabaseClient databaseClient = (DefaultDatabaseClient) DatabaseClient.builder()
-				.connectionFactory(connectionFactory)
-				.dataAccessStrategy(new DefaultReactiveDataAccessStrategy(PostgresDialect.INSTANCE)).build();
+		Statement statement = mockStatementFor("INSERT INTO foo (first, second) VALUES ($1, $2)");
+		DatabaseClient databaseClient = databaseClientBuilder.build();
 
 		databaseClient.insert().into("foo") //
 				.value("first", "foo") //
@@ -260,14 +234,8 @@ public class DefaultDatabaseClientUnitTests {
 	@Test // gh-162
 	public void insertShouldAcceptSettableValue() {
 
-		Statement statement = mock(Statement.class);
-		when(connection.createStatement("INSERT INTO foo (first, second) VALUES ($1, $2)")).thenReturn(statement);
-		when(statement.returnGeneratedValues()).thenReturn(statement);
-		when(statement.execute()).thenReturn(Mono.empty());
-
-		DefaultDatabaseClient databaseClient = (DefaultDatabaseClient) DatabaseClient.builder()
-				.connectionFactory(connectionFactory)
-				.dataAccessStrategy(new DefaultReactiveDataAccessStrategy(PostgresDialect.INSTANCE)).build();
+		Statement statement = mockStatementFor("INSERT INTO foo (first, second) VALUES ($1, $2)");
+		DatabaseClient databaseClient = databaseClientBuilder.build();
 
 		databaseClient.insert().into("foo") //
 				.value("first", SettableValue.from("foo")) //
@@ -283,13 +251,8 @@ public class DefaultDatabaseClientUnitTests {
 	@Test // gh-128
 	public void executeShouldBindNamedValuesByIndex() {
 
-		Statement statement = mock(Statement.class);
-		when(connection.createStatement("SELECT * FROM table WHERE key = $1")).thenReturn(statement);
-		when(statement.execute()).thenReturn(Mono.empty());
-
-		DefaultDatabaseClient databaseClient = (DefaultDatabaseClient) DatabaseClient.builder()
-				.connectionFactory(connectionFactory)
-				.dataAccessStrategy(new DefaultReactiveDataAccessStrategy(PostgresDialect.INSTANCE)).build();
+		Statement statement = mockStatementFor("SELECT * FROM table WHERE key = $1");
+		DatabaseClient databaseClient = databaseClientBuilder.build();
 
 		databaseClient.execute("SELECT * FROM table WHERE key = :key") //
 				.bind("key", "foo") //
@@ -303,14 +266,8 @@ public class DefaultDatabaseClientUnitTests {
 	@Test // gh-177
 	public void deleteNotInShouldRenderCorrectQuery() {
 
-		Statement statement = mock(Statement.class);
-		when(connection.createStatement("DELETE FROM tab WHERE tab.pole = $1 AND tab.id NOT IN ($2, $3)"))
-				.thenReturn(statement);
-		when(statement.execute()).thenReturn(Mono.empty());
-
-		DefaultDatabaseClient databaseClient = (DefaultDatabaseClient) DatabaseClient.builder()
-				.connectionFactory(connectionFactory)
-				.dataAccessStrategy(new DefaultReactiveDataAccessStrategy(PostgresDialect.INSTANCE)).build();
+		Statement statement = mockStatementFor("DELETE FROM tab WHERE tab.pole = $1 AND tab.id NOT IN ($2, $3)");
+		DatabaseClient databaseClient = databaseClientBuilder.build();
 
 		databaseClient.delete().from("tab").matching(where("pole").is("foo").and("id").notIn(1, 2)) //
 				.then() //
@@ -318,23 +275,18 @@ public class DefaultDatabaseClientUnitTests {
 				.verifyComplete();
 
 		verify(statement).bind(0, "foo");
-		verify(statement).bind(1, (Object) 1);
-		verify(statement).bind(2, (Object) 2);
+		verify(statement).bind(1, 1);
+		verify(statement).bind(2, 2);
 	}
 
 	@Test // gh-243
 	public void rowsUpdatedShouldEmitSingleValue() {
 
-		Statement statement = mock(Statement.class);
-		when(connection.createStatement("DROP TABLE tab;")).thenReturn(statement);
 		Result result = mock(Result.class);
-		doReturn(Flux.just(result)).when(statement).execute();
-
-		DefaultDatabaseClient databaseClient = (DefaultDatabaseClient) DatabaseClient.builder()
-				.connectionFactory(connectionFactory)
-				.dataAccessStrategy(new DefaultReactiveDataAccessStrategy(PostgresDialect.INSTANCE)).build();
-
 		when(result.getRowsUpdated()).thenReturn(Mono.empty(), Mono.just(2), Flux.just(1, 2, 3));
+		mockStatementFor("DROP TABLE tab;", result);
+
+		DatabaseClient databaseClient = databaseClientBuilder.build();
 
 		databaseClient.execute("DROP TABLE tab;") //
 				.fetch() //
@@ -361,10 +313,7 @@ public class DefaultDatabaseClientUnitTests {
 	@Test // gh-250
 	public void shouldThrowExceptionForSingleColumnObjectUpdate() {
 
-		DefaultDatabaseClient databaseClient = (DefaultDatabaseClient) DatabaseClient.builder()
-				.connectionFactory(connectionFactory) //
-				.dataAccessStrategy(new DefaultReactiveDataAccessStrategy(PostgresDialect.INSTANCE)) //
-				.build();
+		DatabaseClient databaseClient = databaseClientBuilder.build();
 
 		assertThatIllegalArgumentException().isThrownBy(() -> databaseClient.update() //
 				.table(IdOnly.class) //
@@ -375,20 +324,11 @@ public class DefaultDatabaseClientUnitTests {
 	@Test // gh-260
 	public void shouldProjectGenericExecuteAs() {
 
-		Statement statement = mock(Statement.class);
-		when(connection.createStatement(anyString())).thenReturn(statement);
+		MockResult result = mockSingleColumnResult(MockRow.builder().identified(0, Object.class, "Walter"));
+		mockStatement(result);
 
-		MockRowMetadata metadata = MockRowMetadata.builder()
-				.columnMetadata(MockColumnMetadata.builder().name("name").build()).build();
-		MockResult result = MockResult.builder().rowMetadata(metadata)
-				.row(MockRow.builder().identified(0, Object.class, "Walter").build()).build();
-
-		doReturn(Flux.just(result)).when(statement).execute();
-
-		DatabaseClient databaseClient = DatabaseClient.builder() //
-				.connectionFactory(connectionFactory) //
+		DatabaseClient databaseClient = databaseClientBuilder //
 				.projectionFactory(new SpelAwareProxyProjectionFactory()) //
-				.dataAccessStrategy(new DefaultReactiveDataAccessStrategy(PostgresDialect.INSTANCE)) //
 				.build();
 
 		databaseClient.execute("SELECT * FROM person") //
@@ -408,20 +348,11 @@ public class DefaultDatabaseClientUnitTests {
 	@Test // gh-260
 	public void shouldProjectGenericSelectAs() {
 
-		Statement statement = mock(Statement.class);
-		when(connection.createStatement(anyString())).thenReturn(statement);
+		MockResult result = mockSingleColumnResult(MockRow.builder().identified(0, Object.class, "Walter"));
+		mockStatement(result);
 
-		MockRowMetadata metadata = MockRowMetadata.builder()
-				.columnMetadata(MockColumnMetadata.builder().name("name").build()).build();
-		MockResult result = MockResult.builder().rowMetadata(metadata)
-				.row(MockRow.builder().identified(0, Object.class, "Walter").build()).build();
-
-		doReturn(Flux.just(result)).when(statement).execute();
-
-		DatabaseClient databaseClient = DatabaseClient.builder() //
-				.connectionFactory(connectionFactory) //
+		DatabaseClient databaseClient = databaseClientBuilder //
 				.projectionFactory(new SpelAwareProxyProjectionFactory()) //
-				.dataAccessStrategy(new DefaultReactiveDataAccessStrategy(PostgresDialect.INSTANCE)) //
 				.build();
 
 		databaseClient.select().from("person") //
@@ -442,20 +373,11 @@ public class DefaultDatabaseClientUnitTests {
 	@Test // gh-260
 	public void shouldProjectTypedSelectAs() {
 
-		Statement statement = mock(Statement.class);
-		when(connection.createStatement(anyString())).thenReturn(statement);
+		MockResult result = mockSingleColumnResult(MockRow.builder().identified("name", Object.class, "Walter"));
+		mockStatement(result);
 
-		MockRowMetadata metadata = MockRowMetadata.builder()
-				.columnMetadata(MockColumnMetadata.builder().name("name").build()).build();
-		MockResult result = MockResult.builder().rowMetadata(metadata)
-				.row(MockRow.builder().identified("name", Object.class, "Walter").build()).build();
-
-		doReturn(Flux.just(result)).when(statement).execute();
-
-		DatabaseClient databaseClient = DatabaseClient.builder() //
-				.connectionFactory(connectionFactory) //
+		DatabaseClient databaseClient = databaseClientBuilder //
 				.projectionFactory(new SpelAwareProxyProjectionFactory()) //
-				.dataAccessStrategy(new DefaultReactiveDataAccessStrategy(PostgresDialect.INSTANCE)) //
 				.build();
 
 		databaseClient.select().from(Person.class) //
@@ -474,18 +396,12 @@ public class DefaultDatabaseClientUnitTests {
 	@Test // gh-189
 	public void shouldApplyExecuteFunction() {
 
-		Statement statement = mock(Statement.class);
-		when(connection.createStatement(anyString())).thenReturn(statement);
+		Statement statement = mockStatement();
+		MockResult result = mockSingleColumnResult(MockRow.builder().identified(0, Object.class, "Walter"));
 
-		MockRowMetadata metadata = MockRowMetadata.builder()
-				.columnMetadata(MockColumnMetadata.builder().name("name").build()).build();
-		MockResult result = MockResult.builder().rowMetadata(metadata)
-				.row(MockRow.builder().identified(0, Object.class, "Walter").build()).build();
-
-		DatabaseClient databaseClient = DatabaseClient.builder() //
-				.connectionFactory(connectionFactory) //
-				.dataAccessStrategy(new DefaultReactiveDataAccessStrategy(PostgresDialect.INSTANCE)) //
-				.executeFunction(it -> Mono.just(result)).build();
+		DatabaseClient databaseClient = databaseClientBuilder //
+				.executeFunction(it -> Mono.just(result)) //
+				.build();
 
 		databaseClient.execute("SELECT") //
 				.fetch().all() //
@@ -498,20 +414,13 @@ public class DefaultDatabaseClientUnitTests {
 	@Test // gh-189
 	public void shouldApplyStatementFilterFunctions() {
 
-		Statement statement = mock(Statement.class);
-		when(connection.createStatement(anyString())).thenReturn(statement);
-		when(statement.returnGeneratedValues(anyString())).thenReturn(statement);
-
 		MockRowMetadata metadata = MockRowMetadata.builder()
 				.columnMetadata(MockColumnMetadata.builder().name("name").build()).build();
 		MockResult result = MockResult.builder().rowMetadata(metadata).build();
 
-		doReturn(Flux.just(result)).when(statement).execute();
+		Statement statement = mockStatement(result);
 
-		DatabaseClient databaseClient = DatabaseClient.builder() //
-				.connectionFactory(connectionFactory) //
-				.dataAccessStrategy(new DefaultReactiveDataAccessStrategy(PostgresDialect.INSTANCE)) //
-				.build();
+		DatabaseClient databaseClient = databaseClientBuilder.build();
 
 		databaseClient.execute("SELECT") //
 				.filter((s, next) -> next.execute(s.returnGeneratedValues("foo"))) //
@@ -530,20 +439,13 @@ public class DefaultDatabaseClientUnitTests {
 	@Test // gh-189
 	public void shouldApplyStatementFilterFunctionsToTypedExecute() {
 
-		Statement statement = mock(Statement.class);
-		when(connection.createStatement(anyString())).thenReturn(statement);
-		when(statement.returnGeneratedValues(anyString())).thenReturn(statement);
-
 		MockRowMetadata metadata = MockRowMetadata.builder()
 				.columnMetadata(MockColumnMetadata.builder().name("name").build()).build();
 		MockResult result = MockResult.builder().rowMetadata(metadata).build();
 
-		doReturn(Flux.just(result)).when(statement).execute();
+		Statement statement = mockStatement(result);
 
-		DatabaseClient databaseClient = DatabaseClient.builder() //
-				.connectionFactory(connectionFactory) //
-				.dataAccessStrategy(new DefaultReactiveDataAccessStrategy(PostgresDialect.INSTANCE)) //
-				.build();
+		DatabaseClient databaseClient = databaseClientBuilder.build();
 
 		databaseClient.execute("SELECT") //
 				.filter((s, next) -> next.execute(s.returnGeneratedValues("foo"))) //
@@ -561,20 +463,11 @@ public class DefaultDatabaseClientUnitTests {
 	@Test // gh-189
 	public void shouldApplySimpleStatementFilterFunctions() {
 
-		Statement statement = mock(Statement.class);
-		when(connection.createStatement(anyString())).thenReturn(statement);
-		when(statement.returnGeneratedValues(anyString())).thenReturn(statement);
+		MockResult result = mockSingleColumnEmptyResult();
 
-		MockRowMetadata metadata = MockRowMetadata.builder()
-				.columnMetadata(MockColumnMetadata.builder().name("name").build()).build();
-		MockResult result = MockResult.builder().rowMetadata(metadata).build();
+		Statement statement = mockStatement(result);
 
-		doReturn(Flux.just(result)).when(statement).execute();
-
-		DatabaseClient databaseClient = DatabaseClient.builder() //
-				.connectionFactory(connectionFactory) //
-				.dataAccessStrategy(new DefaultReactiveDataAccessStrategy(PostgresDialect.INSTANCE)) //
-				.build();
+		DatabaseClient databaseClient = databaseClientBuilder.build();
 
 		databaseClient.execute("SELECT") //
 				.filter(s -> s.returnGeneratedValues("foo")) //
@@ -588,6 +481,49 @@ public class DefaultDatabaseClientUnitTests {
 		inOrder.verify(statement).returnGeneratedValues("bar");
 		inOrder.verify(statement).execute();
 		inOrder.verifyNoMoreInteractions();
+	}
+
+	private Statement mockStatement() {
+		return mockStatementFor(null, null);
+	}
+
+	private Statement mockStatement(Result result) {
+		return mockStatementFor(null, result);
+	}
+
+	private Statement mockStatementFor(String sql) {
+		return mockStatementFor(sql, null);
+	}
+
+	private Statement mockStatementFor(@Nullable String sql, @Nullable Result result) {
+
+		Statement statement = mock(Statement.class);
+		when(connection.createStatement(sql == null ? anyString() : eq(sql))).thenReturn(statement);
+		when(statement.returnGeneratedValues(anyString())).thenReturn(statement);
+		when(statement.returnGeneratedValues()).thenReturn(statement);
+
+		doReturn(result == null ? Mono.empty() : Flux.just(result)).when(statement).execute();
+
+		return statement;
+	}
+
+	private MockResult mockSingleColumnEmptyResult() {
+		return mockSingleColumnResult(null);
+	}
+
+	/**
+	 * Mocks a {@link Result} with a single column "name" and a single row if a non null row is provided.
+	 */
+	private MockResult mockSingleColumnResult(@Nullable MockRow.Builder row) {
+
+		MockRowMetadata metadata = MockRowMetadata.builder()
+				.columnMetadata(MockColumnMetadata.builder().name("name").build()).build();
+
+		MockResult.Builder resultBuilder = MockResult.builder().rowMetadata(metadata);
+		if (row != null) {
+			resultBuilder = resultBuilder.row(row.build());
+		}
+		return resultBuilder.build();
 	}
 
 	static class Person {


### PR DESCRIPTION
We now accept `StatementFilterFunction` and `ExecuteFunction` via `DatabaseClient` to filter Statement execution. StatementFilterFunctions can be used to pre-process the statement or post-process Result objects.

```java
databaseClient.execute(…)
		.filter((s, next) -> next.execute(s.returnGeneratedValues("my_id")))
		.filter((s, next) -> next.execute(s.fetchSize(25)))

databaseClient.execute(…)
		.filter(s -> s.returnGeneratedValues("my_id"))
		.filter(s -> s.fetchSize(25))
```

---

Related ticket: #189.