### PR TITLE
#93 - Adding support for optimistic locking based on @Version column

### DIFF
--- a/src/main/java/org/springframework/data/r2dbc/core/DatabaseClient.java
+++ b/src/main/java/org/springframework/data/r2dbc/core/DatabaseClient.java
@@ -48,6 +48,7 @@ import org.springframework.util.Assert;
  * to create an instance.
  *
  * @author Mark Paluch
+ * @author Bogdan Ilchyshyn
  */
 public interface DatabaseClient {
 
@@ -719,9 +720,9 @@ public interface DatabaseClient {
 		 *
 		 * @param objectToUpdate the object of which the attributes will provide the values for the update and the primary
 		 *          key. Must not be {@literal null}.
-		 * @return a {@link UpdateSpec} for further configuration of the update. Guaranteed to be not {@literal null}.
+		 * @return a {@link UpdateMatchingSpec} for further configuration of the update. Guaranteed to be not {@literal null}.
 		 */
-		UpdateSpec using(T objectToUpdate);
+		UpdateMatchingSpec using(T objectToUpdate);
 
 		/**
 		 * Use the given {@code tableName} as update target.

--- a/src/main/java/org/springframework/data/r2dbc/core/R2dbcEntityTemplate.java
+++ b/src/main/java/org/springframework/data/r2dbc/core/R2dbcEntityTemplate.java
@@ -17,6 +17,7 @@ package org.springframework.data.r2dbc.core;
 
 import io.r2dbc.spi.Row;
 import io.r2dbc.spi.RowMetadata;
+import org.springframework.dao.OptimisticLockingFailureException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -30,10 +31,12 @@ import java.util.stream.Collectors;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.core.convert.ConversionService;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.TransientDataAccessResourceException;
 import org.springframework.data.mapping.IdentifierAccessor;
 import org.springframework.data.mapping.MappingException;
+import org.springframework.data.mapping.PersistentPropertyAccessor;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.projection.ProjectionInformation;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
@@ -58,6 +61,7 @@ import org.springframework.util.Assert;
  * prepared in an application context and given to services as bean reference.
  *
  * @author Mark Paluch
+ * @author Bogdan Ilchyshyn
  * @since 1.1
  */
 public class R2dbcEntityTemplate implements R2dbcEntityOperations, BeanFactoryAware {
@@ -372,12 +376,27 @@ public class R2dbcEntityTemplate implements R2dbcEntityOperations, BeanFactoryAw
 
 		RelationalPersistentEntity<T> persistentEntity = getRequiredEntity(entity);
 
+		setVersionIfNecessary(persistentEntity,	entity);
+
 		return this.databaseClient.insert() //
 				.into(persistentEntity.getType()) //
 				.table(tableName).using(entity) //
 				.map(this.dataAccessStrategy.getConverter().populateIdIfNecessary(entity)) //
 				.first() //
 				.defaultIfEmpty(entity);
+	}
+
+	private <T> void setVersionIfNecessary(RelationalPersistentEntity<T> persistentEntity, T entity) {
+		RelationalPersistentProperty versionProperty = persistentEntity.getVersionProperty();
+		if (versionProperty == null) {
+			return;
+		}
+
+		Class<?> versionPropertyType = versionProperty.getType();
+		Long version = versionPropertyType.isPrimitive() ? 1L : 0L;
+		ConversionService conversionService = this.dataAccessStrategy.getConverter().getConversionService();
+		PersistentPropertyAccessor<?> propertyAccessor = persistentEntity.getPropertyAccessor(entity);
+		propertyAccessor.setProperty(versionProperty, conversionService.convert(version, versionPropertyType));
 	}
 
 	/*
@@ -391,19 +410,76 @@ public class R2dbcEntityTemplate implements R2dbcEntityOperations, BeanFactoryAw
 
 		RelationalPersistentEntity<T> persistentEntity = getRequiredEntity(entity);
 
-		return this.databaseClient.update() //
+		DatabaseClient.UpdateMatchingSpec updateMatchingSpec = this.databaseClient.update() //
 				.table(persistentEntity.getType()) //
-				.table(persistentEntity.getTableName()).using(entity) //
-				.fetch().rowsUpdated().handle((rowsUpdated, sink) -> {
+				.table(persistentEntity.getTableName()) //
+				.using(entity);
 
-					if (rowsUpdated == 0) {
-						sink.error(new TransientDataAccessResourceException(
-								String.format("Failed to update table [%s]. Row with Id [%s] does not exist.",
-										persistentEntity.getTableName(), persistentEntity.getIdentifierAccessor(entity).getIdentifier())));
+		DatabaseClient.UpdateSpec updateSpec = updateMatchingSpec;
+		if (persistentEntity.hasVersionProperty()) {
+			updateSpec = updateMatchingSpec.matching(createMatchingVersionCriteria(entity, persistentEntity));
+			incrementVersion(entity, persistentEntity);
+		}
+
+		return updateSpec.fetch() //
+				.rowsUpdated() //
+				.flatMap(rowsUpdated -> rowsUpdated == 0
+						? handleMissingUpdate(entity, persistentEntity) : Mono.just(entity));
+	}
+
+	private <T> Mono<? extends T> handleMissingUpdate(T entity, RelationalPersistentEntity<T> persistentEntity) {
+		if (!persistentEntity.hasVersionProperty()) {
+			return Mono.error(new TransientDataAccessResourceException(
+					formatTransientEntityExceptionMessage(entity, persistentEntity)));
+		}
+
+		return doCount(getByIdQuery(entity, persistentEntity), entity.getClass(), persistentEntity.getTableName())
+				.map(count -> {
+					if (count == 0) {
+						throw new TransientDataAccessResourceException(
+								formatTransientEntityExceptionMessage(entity, persistentEntity));
 					} else {
-						sink.next(entity);
+						throw new OptimisticLockingFailureException(
+								formatOptimisticLockingExceptionMessage(entity, persistentEntity));
 					}
 				});
+	}
+
+	private <T> String formatOptimisticLockingExceptionMessage(T entity, RelationalPersistentEntity<T> persistentEntity) {
+		return String.format("Failed to update table [%s]. Version does not match for row with Id [%s].",
+				persistentEntity.getTableName(), persistentEntity.getIdentifierAccessor(entity).getIdentifier());
+	}
+
+	private <T> String formatTransientEntityExceptionMessage(T entity, RelationalPersistentEntity<T> persistentEntity) {
+		return String.format("Failed to update table [%s]. Row with Id [%s] does not exist.",
+				persistentEntity.getTableName(), persistentEntity.getIdentifierAccessor(entity).getIdentifier());
+	}
+
+	private <T> void incrementVersion(T entity, RelationalPersistentEntity<T> persistentEntity) {
+		PersistentPropertyAccessor<?> propertyAccessor = persistentEntity.getPropertyAccessor(entity);
+		RelationalPersistentProperty versionProperty = persistentEntity.getVersionProperty();
+
+		ConversionService conversionService = this.dataAccessStrategy.getConverter().getConversionService();
+		Object currentVersionValue = propertyAccessor.getProperty(versionProperty);
+		long newVersionValue = 1L;
+		if (currentVersionValue != null) {
+			newVersionValue = conversionService.convert(currentVersionValue, Long.class) + 1;
+		}
+		Class<?> versionPropertyType = versionProperty.getType();
+		propertyAccessor.setProperty(versionProperty, conversionService.convert(newVersionValue, versionPropertyType));
+	}
+
+	private <T> Criteria createMatchingVersionCriteria(T entity, RelationalPersistentEntity<T> persistentEntity) {
+		PersistentPropertyAccessor<?> propertyAccessor = persistentEntity.getPropertyAccessor(entity);
+		RelationalPersistentProperty versionProperty = persistentEntity.getVersionProperty();
+
+		Object version = propertyAccessor.getProperty(versionProperty);
+		Criteria.CriteriaStep versionColumn = Criteria.where(dataAccessStrategy.toSql(versionProperty.getColumnName()));
+		if (version == null) {
+			return versionColumn.isNull();
+		} else {
+			return versionColumn.is(version);
+		}
 	}
 
 	/*

--- a/src/test/java/org/springframework/data/r2dbc/testing/H2TestSupport.java
+++ b/src/test/java/org/springframework/data/r2dbc/testing/H2TestSupport.java
@@ -27,11 +27,13 @@ import org.springframework.jdbc.datasource.DriverManagerDataSource;
  * Utility class for testing against H2.
  *
  * @author Mark Paluch
+ * @author Bogdan Ilchyshyn
  */
 public class H2TestSupport {
 
 	public static String CREATE_TABLE_LEGOSET = "CREATE TABLE legoset (\n" //
 			+ "    id          integer CONSTRAINT id PRIMARY KEY,\n" //
+			+ "    version     integer NULL,\n" //
 			+ "    name        varchar(255) NOT NULL,\n" //
 			+ "    manual      integer NULL\n," //
 			+ "    cert        bytea NULL\n" //
@@ -39,6 +41,7 @@ public class H2TestSupport {
 
 	public static String CREATE_TABLE_LEGOSET_WITH_ID_GENERATION = "CREATE TABLE legoset (\n" //
 			+ "    id          serial CONSTRAINT id PRIMARY KEY,\n" //
+			+ "    version     integer NULL,\n" //
 			+ "    name        varchar(255) NOT NULL,\n" //
 			+ "    manual      integer NULL\n" //
 			+ ");";

--- a/src/test/java/org/springframework/data/r2dbc/testing/MySqlTestSupport.java
+++ b/src/test/java/org/springframework/data/r2dbc/testing/MySqlTestSupport.java
@@ -35,6 +35,7 @@ import com.mysql.jdbc.jdbc2.optional.MysqlDataSource;
  * Utility class for testing against MySQL.
  *
  * @author Mark Paluch
+ * @author Bogdan Ilchyshyn
  */
 public class MySqlTestSupport {
 
@@ -42,6 +43,7 @@ public class MySqlTestSupport {
 
 	public static String CREATE_TABLE_LEGOSET = "CREATE TABLE legoset (\n" //
 			+ "    id          integer PRIMARY KEY,\n" //
+			+ "    version     integer NULL,\n" //
 			+ "    name        varchar(255) NOT NULL,\n" //
 			+ "    manual      integer NULL\n," //
 			+ "    cert        varbinary(255) NULL\n" //
@@ -49,6 +51,7 @@ public class MySqlTestSupport {
 
 	public static String CREATE_TABLE_LEGOSET_WITH_ID_GENERATION = "CREATE TABLE legoset (\n" //
 			+ "    id          integer AUTO_INCREMENT PRIMARY KEY,\n" //
+			+ "    version     integer NULL,\n" //
 			+ "    name        varchar(255) NOT NULL,\n" //
 			+ "    manual      integer NULL\n" //
 			+ ") ENGINE=InnoDB;";

--- a/src/test/java/org/springframework/data/r2dbc/testing/PostgresTestSupport.java
+++ b/src/test/java/org/springframework/data/r2dbc/testing/PostgresTestSupport.java
@@ -18,6 +18,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
  *
  * @author Mark Paluch
  * @author Jens Schauder
+ * @author Bogdan Ilchyshyn
  */
 public class PostgresTestSupport {
 
@@ -25,6 +26,7 @@ public class PostgresTestSupport {
 
 	public static String CREATE_TABLE_LEGOSET = "CREATE TABLE legoset (\n" //
 			+ "    id          integer CONSTRAINT id PRIMARY KEY,\n" //
+			+ "    version     integer NULL,\n" //
 			+ "    name        varchar(255) NOT NULL,\n" //
 			+ "    manual      integer NULL\n," //
 			+ "    cert        bytea NULL\n" //
@@ -32,6 +34,7 @@ public class PostgresTestSupport {
 
 	public static String CREATE_TABLE_LEGOSET_WITH_ID_GENERATION = "CREATE TABLE legoset (\n" //
 			+ "    id          serial CONSTRAINT id PRIMARY KEY,\n" //
+			+ "    version     integer NULL,\n" //
 			+ "    name        varchar(255) NOT NULL,\n" //
 			+ "    manual      integer NULL\n" //
 			+ ");";

--- a/src/test/java/org/springframework/data/r2dbc/testing/SqlServerTestSupport.java
+++ b/src/test/java/org/springframework/data/r2dbc/testing/SqlServerTestSupport.java
@@ -12,11 +12,13 @@ import com.microsoft.sqlserver.jdbc.SQLServerDataSource;
  * Utility class for testing against Microsoft SQL Server.
  *
  * @author Mark Paluch
+ * @author Bogdan Ilchyshyn
  */
 public class SqlServerTestSupport {
 
 	public static String CREATE_TABLE_LEGOSET = "CREATE TABLE legoset (\n" //
 			+ "    id          integer PRIMARY KEY,\n" //
+			+ "    version     integer NULL,\n" //
 			+ "    name        varchar(255) NOT NULL,\n" //
 			+ "    manual      integer NULL\n," //
 			+ "    cert        varbinary(255) NULL\n" //
@@ -24,6 +26,7 @@ public class SqlServerTestSupport {
 
 	public static String CREATE_TABLE_LEGOSET_WITH_ID_GENERATION = "CREATE TABLE legoset (\n" //
 			+ "    id          integer IDENTITY(1,1) PRIMARY KEY,\n" //
+			+ "    version     integer NULL,\n" //
 			+ "    name        varchar(255) NOT NULL,\n" //
 			+ "    manual      integer NULL\n" //
 			+ ");";


### PR DESCRIPTION
This PR is a proposal for implementation of optimistic locking (#93). Suggested solution was heavily inspired by spring-projects/spring-data-jdbc#124.

Current tests are failing, and I need an advice from the project members what would be the best way to resolve it.
The thing is that typically `OptimisticLockingException` is expected by a user if update failed due to version mismatch (expected result in the tests). But previous implementation already used ID criteria during update query execution and now fails with `TransientDataAccessResourceException` if query did not update any rows (regardless if version or ID did not match). I do not see any way to distinguish between ID/version mismatches but executing an additional query in the failure case to throw a proper exception. But this obviously has a cost. At the same time using `TransientDataAccessResourceException` for optimistic locking does not seem to be a good design. And `TransientDataAccessResourceException` is already a part of API contract, just replacing it with `OptimisticLockingException` would mean an incompatible contract change. So all available options seems to have downsides to me..    