### PR TITLE
Allow saving an entity with a read-only collection-like property.

### DIFF
--- a/src/main/java/org/springframework/data/r2dbc/core/DefaultReactiveDataAccessStrategy.java
+++ b/src/main/java/org/springframework/data/r2dbc/core/DefaultReactiveDataAccessStrategy.java
@@ -206,7 +206,7 @@ public class DefaultReactiveDataAccessStrategy implements ReactiveDataAccessStra
 		for (RelationalPersistentProperty property : entity) {
 
 			SettableValue value = row.get(property.getColumnName());
-			if (shouldConvertArrayValue(property, value)) {
+			if (value != null && shouldConvertArrayValue(property, value)) {
 
 				SettableValue writeValue = getArrayValue(value, property);
 				row.put(property.getColumnName(), writeValue);


### PR DESCRIPTION
Previously a NullPointerException would be thrown.

Fixes #354 