### PR TITLE
#373 - Use SpelQueryContext for expression query parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>1.2.0-SNAPSHOT</version>
+	<version>1.2.0-GH-373-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC</description>

--- a/src/test/java/org/springframework/data/r2dbc/repository/query/ExpressionQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/query/ExpressionQueryUnitTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.repository.query;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ExpressionQuery}.
+ *
+ * @author Mark Paluch
+ */
+public class ExpressionQueryUnitTests {
+
+	@Test // gh-373
+	public void bindsMultipleSpelParametersCorrectly() {
+
+		ExpressionQuery query = ExpressionQuery
+				.create("INSERT IGNORE INTO table (x, y) VALUES (:#{#point.x}, :#{#point.y})");
+
+		assertThat(query.getQuery())
+				.isEqualTo("INSERT IGNORE INTO table (x, y) VALUES (:__synthetic_0__, :__synthetic_1__)");
+
+		assertThat(query.getBindings()).hasSize(2);
+		assertThat(query.getBindings().get(0).getExpression()).isEqualTo("#point.x");
+		assertThat(query.getBindings().get(0).getParameterName()).isEqualTo("__synthetic_0__");
+		assertThat(query.getBindings().get(1).getExpression()).isEqualTo("#point.y");
+		assertThat(query.getBindings().get(1).getParameterName()).isEqualTo("__synthetic_1__");
+	}
+}

--- a/src/test/java/org/springframework/data/r2dbc/repository/query/StringBasedR2dbcQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/query/StringBasedR2dbcQueryUnitTests.java
@@ -238,23 +238,6 @@ public class StringBasedR2dbcQueryUnitTests {
 		verifyNoMoreInteractions(bindSpec);
 	}
 
-	@Test // gh-373
-	public void bindsMultipleSpelParametersCorrectly() {
-
-		StringBasedR2dbcQuery query = getQueryMethod("queryWithTwoSpelExpressions", Point.class);
-		R2dbcParameterAccessor accessor = new R2dbcParameterAccessor(query.getQueryMethod(), new Point(1, 2));
-
-		BindableQuery stringQuery = query.createQuery(accessor);
-
-		assertThat(stringQuery.get())
-				.isEqualTo("INSERT IGNORE INTO table (x, y) VALUES (:__synthetic_0__, :__synthetic_1__)");
-		assertThat(stringQuery.bind(bindSpec)).isNotNull();
-
-		verify(bindSpec).bind("__synthetic_0__", 1d);
-		verify(bindSpec).bind("__synthetic_1__", 2d);
-		verifyNoMoreInteractions(bindSpec);
-	}
-
 	private StringBasedR2dbcQuery getQueryMethod(String name, Class<?>... args) {
 
 		Method method = ReflectionUtils.findMethod(SampleRepository.class, name, args);
@@ -300,9 +283,6 @@ public class StringBasedR2dbcQueryUnitTests {
 
 		@Query("SELECT * FROM person WHERE lastname = :name")
 		Person queryWithUnusedParameter(String name, Sort unused);
-
-		@Query("INSERT IGNORE INTO table (x, y) VALUES (:#{#point.x}, :#{#point.y})")
-		Person queryWithTwoSpelExpressions(@Param("point") Point point);
 	}
 
 	static class Person {


### PR DESCRIPTION
We now use SpelQueryContext and SpelExtractor for analysis and rewrite of queries using SpEL.

---

Needs backport to 1.1.x.