### PR TITLE
Wording changes

### DIFF
--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -14,7 +14,7 @@
 
 * Upgrade to R2DBC 0.8.0.RELEASE.
 * `@Modifying` annotation for query methods to consume affected row count.
-* Repository `save(…)` with an associated Id terminates with `TransientDataAccessException` if the row does not exist in the database.
+* Repository `save(…)` with an associated ID ends with `TransientDataAccessException` if the row does not exist in the database.
 * Added `SingleConnectionConnectionFactory` for testing using connection singletons.
 * Support for {spring-framework-ref}/core.html#expressions[SpEL expressions] in `@Query`.
 

--- a/src/main/asciidoc/reference/r2dbc-fluent.adoc
+++ b/src/main/asciidoc/reference/r2dbc-fluent.adoc
@@ -132,7 +132,7 @@ Mono<Void> insert = databaseClient.insert()
 <1> Using `Person` with the `into(…)` method sets the `INTO` table, based on mapping metadata.
 It also prepares the insert statement to accept `Person` objects for inserting.
 <2> Provide a scalar `Person` object.
-Alternatively, you can supply a `Publisher` to execute a stream of `INSERT` statements.
+Alternatively, you can supply a `Publisher` to run a stream of `INSERT` statements.
 This method extracts all non-`null` values and inserts them.
 <3> Use `then()` to insert an object without consuming further details.
 Modifying statements allow consumption of the number of affected rows or tabular results for consuming generated keys.
@@ -171,7 +171,7 @@ By default, it returns results as `Map<String, Object>`.
 * *value* `(String, Object)`: Provides a column value to insert.
 * *nullValue* `(String)`: Provides a null value to insert.
 * *map* `(BiFunction<Row, RowMetadata, T>)`: Supplies a mapping function to extract results.
-* *then* `()`: Executes `INSERT` without consuming any results.
+* *then* `()`: Runs `INSERT` without consuming any results.
 * *fetch* `()`: Transition call declaration to the fetch stage to declare result consumption multiplicity.
 
 [[r2dbc.datbaseclient.fluent-api.update]]

--- a/src/main/asciidoc/reference/r2dbc-repositories.adoc
+++ b/src/main/asciidoc/reference/r2dbc-repositories.adoc
@@ -279,7 +279,7 @@ Alternatively, you can add custom modifying behavior by using the facilities des
 === Queries with SpEL Expressions
 
 Query string definitions can be used together with SpEL expressions to create dynamic queries at runtime.
-SpEL expressions can provide predicate values which are evaluated right before executing the query.
+SpEL expressions can provide predicate values which are evaluated right before running the query.
 
 Expressions expose method arguments through an array that contains all the arguments.
 The following query uses `[0]`
@@ -335,4 +335,3 @@ With auto-increment columns, this happens automatically, because the ID gets set
 
 :projection-collection: Flux
 include::../{spring-data-commons-docs}/repository-projections.adoc[leveloffset=+2]
-

--- a/src/main/asciidoc/reference/r2dbc-sql.adoc
+++ b/src/main/asciidoc/reference/r2dbc-sql.adoc
@@ -16,7 +16,7 @@ Mono<Void> completion = client.execute("CREATE TABLE person (id VARCHAR(255) PRI
 It exposes intermediate, continuation, and terminal methods at each stage of the execution specification.
 The preceding example above uses `then()` to return a completion `Publisher` that completes as soon as the query (or queries, if the SQL query contains multiple statements) completes.
 
-NOTE: `execute(…)` accepts either the SQL query string or a query `Supplier<String>` to defer the actual query creation until execution.
+NOTE: `execute(…)` accepts either the SQL query string or a query `Supplier<String>` to defer the actual query creation until the query is run.
 
 [[r2dbc.datbaseclient.queries]]
 == Running Queries
@@ -104,7 +104,7 @@ These are typically `SELECT` statements constrained by a `WHERE` clause or `INSE
 Parameterized statements bear the risk of SQL injection if parameters are not escaped properly.
 `DatabaseClient` leverages R2DBC's `bind` API to eliminate the risk of SQL injection for query parameters.
 You can provide a parameterized SQL statement with the `execute(…)` operator and bind parameters to the actual `Statement`.
-Your R2DBC driver then executes the statement by using prepared statements and parameter substitution.
+Your R2DBC driver then runs the statement by using prepared statements and parameter substitution.
 
 Parameter binding supports two binding strategies:
 
@@ -130,11 +130,11 @@ As an example, Postgres uses indexed markers, such as `$1`, `$2`, `$n`.
 Another example is SQL Server, which uses named bind markers prefixed with `@`.
 
 This is different from JDBC, which requires `?` as bind markers.
-In JDBC, the actual drivers translate `?` bind markers to database-native markers as part of their statement execution.
+In JDBC, the actual drivers translate `?` bind markers to database-native markers as part of processing the statement.
 
 Spring Data R2DBC lets you use native bind markers or named bind markers with the `:name` syntax.
 
-Named parameter support leverages a `R2dbcDialect` instance to expand named parameters to native bind markers at the time of query execution, which gives you a certain degree of query portability across various database vendors.
+Named parameter support uses a `R2dbcDialect` instance to expand named parameters to native bind markers at the time of running the query, which gives you a certain degree of query portability across various database vendors.
 ****
 
 The query-preprocessor unrolls named `Collection` parameters into a series of bind markers to remove the need of dynamic query creation based on the number of arguments.
@@ -149,7 +149,7 @@ SELECT id, name, state FROM table WHERE (name, age) IN (('John', 35), ('Ann', 50
 ----
 ====
 
-The preceding query can be parametrized and executed as follows:
+The preceding query can be parametrized and run as follows:
 
 ====
 [source,java]
@@ -178,7 +178,7 @@ db.execute("SELECT id, name, state FROM table WHERE age IN (:ages)")
 [[r2dbc.datbaseclient.filter]]
 == Statement Filters
 
-You can register a `Statement` filter (`StatementFilterFunction`) through `DatabaseClient` to intercept and modify statements in their execution, as the following example shows:
+You can register a `Statement` filter (`StatementFilterFunction`) through `DatabaseClient` to intercept and modify statements when they run, as the following example shows:
 
 ====
 [source,java]
@@ -205,4 +205,4 @@ db.execute("SELECT id, name, state FROM table")
 ----
 ====
 
-`StatementFilterFunction` allow filtering of the executed `Statement` and filtering of `Result` objects.
+`StatementFilterFunction` allows filtering of the `Statement` and filtering of the `Result` objects.


### PR DESCRIPTION
Replace potentially insensitive language with more neutral language.

Note that problematic words in the code have
to remain in the docs until the code changes.