### PR TITLE
#215 - Add support for EntityCallbacks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-r2dbc</artifactId>
-	<version>1.2.0-SNAPSHOT</version>
+	<version>1.2.0-gh-215-SNAPSHOT</version>
 
 	<name>Spring Data R2DBC</name>
 	<description>Spring Data module for R2DBC</description>

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -1,7 +1,13 @@
 [[new-features]]
 = New & Noteworthy
 
+[[new-features.1-2-0]]
+== What's New in Spring Data R2DBC 1.2.0
+
+* Support for <<entity-callbacks>>.
+
 [[new-features.1-1-0-RELEASE]]
+
 == What's New in Spring Data R2DBC 1.1.0 RELEASE
 
 * Introduction of `R2dbcEntityTemplate` for entity-oriented operations.

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -6,42 +6,29 @@
 
 * Support for <<entity-callbacks>>.
 
-[[new-features.1-1-0-RELEASE]]
-
-== What's New in Spring Data R2DBC 1.1.0 RELEASE
+[[new-features.1-1-0]]
+== What's New in Spring Data R2DBC 1.1.0
 
 * Introduction of `R2dbcEntityTemplate` for entity-oriented operations.
 * <<r2dbc.repositories.queries,Query derivation>>.
 * Support interface projections with `DatabaseClient.as(…)`.
 * <<r2dbc.datbaseclient.filter,Support for `ExecuteFunction` and `StatementFilterFunction` via `DatabaseClient.filter(…)`>>.
 
-[[new-features.1-0-0-RELEASE]]
-== What's New in Spring Data R2DBC 1.0.0 RELEASE
+[[new-features.1-0-0]]
+== What's New in Spring Data R2DBC 1.0.0
 
 * Upgrade to R2DBC 0.8.0.RELEASE.
 * `@Modifying` annotation for query methods to consume affected row count.
 * Repository `save(…)` with an associated Id terminates with `TransientDataAccessException` if the row does not exist in the database.
 * Added `SingleConnectionConnectionFactory` for testing using connection singletons.
 * Support for {spring-framework-ref}/core.html#expressions[SpEL expressions] in `@Query`.
-
-[[new-features.1-0-0-RC1]]
-== What's New in Spring Data R2DBC 1.0.0 RC1
-
 * `ConnectionFactory` routing through `AbstractRoutingConnectionFactory`.
 * Utilities for schema initialization through `ResourceDatabasePopulator` and `ScriptUtils`.
 * Propagation and reset of Auto-Commit and Isolation Level control through `TransactionDefinition`.
 * Support for Entity-level converters.
 * Kotlin extensions for reified generics and <<kotlin.coroutines,Coroutines>>.
 * Add pluggable mechanism to register dialects.
-
-[[new-features.1-0-0-M2]]
-== What's New in Spring Data R2DBC 1.0.0 M2
-
 * Support for named parameters.
-
-[[new-features.1-0-0-M1]]
-== What's New in Spring Data R2DBC 1.0.0 M1
-
 * Initial R2DBC support through `DatabaseClient`.
 * Initial Transaction support through `TransactionalDatabaseClient`.
 * Initial R2DBC Repository Support through `R2dbcRepository`.

--- a/src/main/asciidoc/reference/r2dbc-entity-callbacks.adoc
+++ b/src/main/asciidoc/reference/r2dbc-entity-callbacks.adoc
@@ -1,0 +1,38 @@
+[[r2dbc.entity-callbacks]]
+= Store specific EntityCallbacks
+
+Spring Data R2DBC uses the `EntityCallback` API and reacts on the following callbacks.
+
+.Supported Entity Callbacks
+[%header,cols="4"]
+|===
+| Callback
+| Method
+| Description
+| Order
+
+| BeforeConvertCallback
+| `onBeforeConvert(T entity, SqlIdentifier table)`
+| Invoked before a domain object is converted to `OutboundRow`.
+| `Ordered.LOWEST_PRECEDENCE`
+
+| AfterConvertCallback
+| `onAfterConvert(T entity, SqlIdentifier table)`
+| Invoked after a domain object is loaded. +
+Can modify the domain object after reading it from a row.
+| `Ordered.LOWEST_PRECEDENCE`
+
+| BeforeSaveCallback
+| `onBeforeSave(T entity, OutboundRow row, SqlIdentifier table)`
+| Invoked before a domain object is saved. +
+Can modify the target, to be persisted, `OutboundRow` containing all mapped entity information.
+| `Ordered.LOWEST_PRECEDENCE`
+
+| AfterSaveCallback
+| `onAfterSave(T entity, OutboundRow row, SqlIdentifier table)`
+| Invoked before a domain object is saved. +
+Can modify the domain object, to be returned after save, `OutboundRow` containing all mapped entity information.
+| `Ordered.LOWEST_PRECEDENCE`
+
+|===
+

--- a/src/main/asciidoc/reference/r2dbc-repositories.adoc
+++ b/src/main/asciidoc/reference/r2dbc-repositories.adoc
@@ -336,3 +336,6 @@ With auto-increment columns, this happens automatically, because the ID gets set
 :projection-collection: Flux
 include::../{spring-data-commons-docs}/repository-projections.adoc[leveloffset=+2]
 
+include::../{spring-data-commons-docs}/entity-callbacks.adoc[leveloffset=+1]
+include::./r2dbc-entity-callbacks.adoc[leveloffset=+2]
+

--- a/src/main/java/org/springframework/data/r2dbc/core/ReactiveSelectOperationSupport.java
+++ b/src/main/java/org/springframework/data/r2dbc/core/ReactiveSelectOperationSupport.java
@@ -127,7 +127,8 @@ class ReactiveSelectOperationSupport implements ReactiveSelectOperation {
 		 */
 		@Override
 		public Mono<T> first() {
-			return this.template.doSelect(this.query.limit(1), this.domainType, getTableName(), this.returnType).first();
+			return this.template.doSelect(this.query.limit(1), this.domainType, getTableName(), this.returnType,
+					RowsFetchSpec::first);
 		}
 
 		/*
@@ -136,7 +137,8 @@ class ReactiveSelectOperationSupport implements ReactiveSelectOperation {
 		 */
 		@Override
 		public Mono<T> one() {
-			return this.template.doSelect(this.query.limit(2), this.domainType, getTableName(), this.returnType).one();
+			return this.template.doSelect(this.query.limit(2), this.domainType, getTableName(), this.returnType,
+					RowsFetchSpec::one);
 		}
 
 		/*
@@ -145,7 +147,7 @@ class ReactiveSelectOperationSupport implements ReactiveSelectOperation {
 		 */
 		@Override
 		public Flux<T> all() {
-			return this.template.doSelect(this.query, this.domainType, getTableName(), this.returnType).all();
+			return this.template.doSelect(this.query, this.domainType, getTableName(), this.returnType, RowsFetchSpec::all);
 		}
 
 		private SqlIdentifier getTableName() {

--- a/src/main/java/org/springframework/data/r2dbc/mapping/event/AfterConvertCallback.java
+++ b/src/main/java/org/springframework/data/r2dbc/mapping/event/AfterConvertCallback.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.mapping.event;
+
+import org.reactivestreams.Publisher;
+
+import org.springframework.data.mapping.callback.EntityCallback;
+import org.springframework.data.relational.core.sql.SqlIdentifier;
+
+/**
+ * Callback being invoked after a domain object is materialized from a row when reading results.
+ *
+ * @author Mark Paluch
+ * @since 1.2
+ * @see org.springframework.data.mapping.callback.ReactiveEntityCallbacks
+ */
+@FunctionalInterface
+public interface AfterConvertCallback<T> extends EntityCallback<T> {
+
+	/**
+	 * Entity callback method invoked after a domain object is materialized from a row. Can return either the same or a
+	 * modified instance of the domain object.
+	 *
+	 * @param entity the domain object (the result of the conversion).
+	 * @param table name of the table.
+	 * @return the domain object that is the result of reading it from a row.
+	 */
+	Publisher<T> onAfterConvert(T entity, SqlIdentifier table);
+}

--- a/src/main/java/org/springframework/data/r2dbc/mapping/event/AfterSaveCallback.java
+++ b/src/main/java/org/springframework/data/r2dbc/mapping/event/AfterSaveCallback.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.mapping.event;
+
+import org.reactivestreams.Publisher;
+
+import org.springframework.data.mapping.callback.EntityCallback;
+import org.springframework.data.r2dbc.mapping.OutboundRow;
+import org.springframework.data.relational.core.sql.SqlIdentifier;
+
+/**
+ * Entity callback triggered after save of a {@link OutboundRow}.
+ *
+ * @author Mark Paluch
+ * @since 1.2
+ * @see org.springframework.data.mapping.callback.ReactiveEntityCallbacks
+ */
+@FunctionalInterface
+public interface AfterSaveCallback<T> extends EntityCallback<T> {
+
+	/**
+	 * Entity callback method invoked after a domain object is saved. Can return either the same or a modified instance of
+	 * the domain object.
+	 *
+	 * @param entity the domain object that was saved.
+	 * @param outboundRow {@link OutboundRow} representing the {@code entity}.
+	 * @param table name of the table.
+	 * @return the domain object that was persisted.
+	 */
+	Publisher<T> onAfterSave(T entity, OutboundRow outboundRow, SqlIdentifier table);
+}

--- a/src/main/java/org/springframework/data/r2dbc/mapping/event/BeforeConvertCallback.java
+++ b/src/main/java/org/springframework/data/r2dbc/mapping/event/BeforeConvertCallback.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.mapping.event;
+
+import org.reactivestreams.Publisher;
+
+import org.springframework.data.mapping.callback.EntityCallback;
+import org.springframework.data.relational.core.sql.SqlIdentifier;
+
+/**
+ * Callback being invoked before a domain object is converted to be persisted.
+ *
+ * @author Mark Paluch
+ * @since 1.2
+ * @see org.springframework.data.mapping.callback.ReactiveEntityCallbacks
+ */
+@FunctionalInterface
+public interface BeforeConvertCallback<T> extends EntityCallback<T> {
+
+	/**
+	 * Entity callback method invoked before a domain object is converted to be persisted. Can return either the same or a
+	 * modified instance of the domain object.
+	 *
+	 * @param entity the domain object to save.
+	 * @param table name of the table.
+	 * @return the domain object to be persisted.
+	 */
+	Publisher<T> onBeforeConvert(T entity, SqlIdentifier table);
+}

--- a/src/main/java/org/springframework/data/r2dbc/mapping/event/BeforeSaveCallback.java
+++ b/src/main/java/org/springframework/data/r2dbc/mapping/event/BeforeSaveCallback.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.mapping.event;
+
+import org.reactivestreams.Publisher;
+
+import org.springframework.data.mapping.callback.EntityCallback;
+import org.springframework.data.r2dbc.mapping.OutboundRow;
+import org.springframework.data.relational.core.sql.SqlIdentifier;
+
+/**
+ * Entity callback triggered before save of a row.
+ *
+ * @author Mark Paluch
+ * @since 1.2
+ * @see org.springframework.data.mapping.callback.ReactiveEntityCallbacks
+ */
+@FunctionalInterface
+public interface BeforeSaveCallback<T> extends EntityCallback<T> {
+
+	/**
+	 * Entity callback method invoked before a domain object is saved. Can return either the same or a modified instance
+	 * of the domain object and can modify {@link OutboundRow} contents. This method is called after converting the
+	 * {@code entity} to a {@link OutboundRow} so effectively the row is used as outcome of invoking this callback.
+	 * Changes to the domain object are not taken into account for saving, only changes to the row. Only transient fields
+	 * of the entity should be changed in this callback. To change persistent the entity before being converted, use the
+	 * {@link BeforeConvertCallback}.
+	 *
+	 * @param entity the domain object to save.
+	 * @param row {@link OutboundRow} representing the {@code entity}.
+	 * @param table name of the table.
+	 * @return the domain object to be persisted.
+	 */
+	Publisher<T> onBeforeSave(T entity, OutboundRow row, SqlIdentifier table);
+}

--- a/src/main/java/org/springframework/data/r2dbc/mapping/event/package-info.java
+++ b/src/main/java/org/springframework/data/r2dbc/mapping/event/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Mapping event callback infrastructure for the R2DBC row-to-object mapping subsystem.
+ */
+@org.springframework.lang.NonNullApi
+package org.springframework.data.r2dbc.mapping.event;

--- a/src/test/java/org/springframework/data/r2dbc/core/R2dbcEntityTemplateUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/core/R2dbcEntityTemplateUnitTests.java
@@ -21,11 +21,15 @@ import io.r2dbc.spi.test.MockColumnMetadata;
 import io.r2dbc.spi.test.MockResult;
 import io.r2dbc.spi.test.MockRow;
 import io.r2dbc.spi.test.MockRowMetadata;
+import lombok.ToString;
 import lombok.Value;
 import lombok.With;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -33,13 +37,22 @@ import org.junit.Test;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Version;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.mapping.callback.ReactiveEntityCallbacks;
 import org.springframework.data.r2dbc.dialect.PostgresDialect;
+import org.springframework.data.r2dbc.mapping.OutboundRow;
 import org.springframework.data.r2dbc.mapping.SettableValue;
+import org.springframework.data.r2dbc.mapping.event.AfterConvertCallback;
+import org.springframework.data.r2dbc.mapping.event.AfterSaveCallback;
+import org.springframework.data.r2dbc.mapping.event.BeforeConvertCallback;
+import org.springframework.data.r2dbc.mapping.event.BeforeSaveCallback;
 import org.springframework.data.r2dbc.testing.StatementRecorder;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.query.Criteria;
 import org.springframework.data.relational.core.query.Query;
 import org.springframework.data.relational.core.query.Update;
+import org.springframework.data.relational.core.sql.SqlIdentifier;
+import org.springframework.lang.Nullable;
+import org.springframework.util.CollectionUtils;
 
 /**
  * Unit tests for {@link R2dbcEntityTemplate}.
@@ -117,6 +130,31 @@ public class R2dbcEntityTemplateUnitTests {
 		assertThat(statement.getSql())
 				.isEqualTo("SELECT person.* FROM person WHERE person.THE_NAME = $1 ORDER BY THE_NAME ASC");
 		assertThat(statement.getBindings()).hasSize(1).containsEntry(0, SettableValue.from("Walter"));
+	}
+
+	@Test // gh-215
+	public void selectShouldInvokeCallback() {
+
+		MockRowMetadata metadata = MockRowMetadata.builder().columnMetadata(MockColumnMetadata.builder().name("id").build())
+				.columnMetadata(MockColumnMetadata.builder().name("THE_NAME").build()).build();
+		MockResult result = MockResult.builder().rowMetadata(metadata).row(MockRow.builder()
+				.identified("id", Object.class, "Walter").identified("THE_NAME", Object.class, "some-name").build()).build();
+
+		recorder.addStubbing(s -> s.startsWith("SELECT"), result);
+
+		ValueCapturingAfterConvertCallback callback = new ValueCapturingAfterConvertCallback();
+
+		entityTemplate.setEntityCallbacks(ReactiveEntityCallbacks.create(callback));
+
+		entityTemplate.select(Query.empty(), Person.class) //
+				.as(StepVerifier::create) //
+				.consumeNextWith(actual -> {
+
+					assertThat(actual.id).isEqualTo("after-convert");
+					assertThat(actual.name).isEqualTo("some-name");
+				}).verifyComplete();
+
+		assertThat(callback.getValues()).hasSize(1);
 	}
 
 	@Test // gh-220
@@ -215,6 +253,34 @@ public class R2dbcEntityTemplateUnitTests {
 				SettableValue.from(1L));
 	}
 
+	@Test // gh-215
+	public void insertShouldInvokeCallback() {
+
+		MockRowMetadata metadata = MockRowMetadata.builder().build();
+		MockResult result = MockResult.builder().rowMetadata(metadata).rowsUpdated(1).build();
+
+		recorder.addStubbing(s -> s.startsWith("INSERT"), result);
+
+		ValueCapturingBeforeConvertCallback beforeConvert = new ValueCapturingBeforeConvertCallback();
+		ValueCapturingBeforeSaveCallback beforeSave = new ValueCapturingBeforeSaveCallback();
+		ValueCapturingAfterSaveCallback afterSave = new ValueCapturingAfterSaveCallback();
+
+		entityTemplate.setEntityCallbacks(ReactiveEntityCallbacks.create(beforeConvert, beforeSave, afterSave));
+		entityTemplate.insert(new Person()).as(StepVerifier::create) //
+				.assertNext(actual -> {
+					assertThat(actual.id).isEqualTo("after-save");
+					assertThat(actual.name).isEqualTo("before-convert");
+					assertThat(actual.description).isNull();
+				}) //
+				.verifyComplete();
+
+		StatementRecorder.RecordedStatement statement = recorder.getCreatedStatement(s -> s.startsWith("INSERT"));
+
+		assertThat(statement.getSql()).isEqualTo("INSERT INTO person (THE_NAME, description) VALUES ($1, $2)");
+		assertThat(statement.getBindings()).hasSize(2).containsEntry(0, SettableValue.from("before-convert"))
+				.containsEntry(1, SettableValue.from("before-save"));
+	}
+
 	@Test // gh-365
 	public void shouldUpdateVersioned() {
 
@@ -237,11 +303,47 @@ public class R2dbcEntityTemplateUnitTests {
 				SettableValue.from(1L));
 	}
 
+	@Test // gh-215
+	public void updateShouldInvokeCallback() {
+
+		MockRowMetadata metadata = MockRowMetadata.builder().build();
+		MockResult result = MockResult.builder().rowMetadata(metadata).rowsUpdated(1).build();
+
+		recorder.addStubbing(s -> s.startsWith("UPDATE"), result);
+
+		ValueCapturingBeforeConvertCallback beforeConvert = new ValueCapturingBeforeConvertCallback();
+		ValueCapturingBeforeSaveCallback beforeSave = new ValueCapturingBeforeSaveCallback();
+		ValueCapturingAfterSaveCallback afterSave = new ValueCapturingAfterSaveCallback();
+
+		Person person = new Person();
+		person.id = "the-id";
+		person.name = "name";
+		person.description = "description";
+
+		entityTemplate.setEntityCallbacks(ReactiveEntityCallbacks.create(beforeConvert, beforeSave, afterSave));
+		entityTemplate.update(person).as(StepVerifier::create) //
+				.assertNext(actual -> {
+					assertThat(actual.id).isEqualTo("after-save");
+					assertThat(actual.name).isEqualTo("before-convert");
+					assertThat(actual.description).isNull();
+				}) //
+				.verifyComplete();
+
+		StatementRecorder.RecordedStatement statement = recorder.getCreatedStatement(s -> s.startsWith("UPDATE"));
+
+		assertThat(statement.getSql()).isEqualTo("UPDATE person SET THE_NAME = $1, description = $2 WHERE person.id = $3");
+		assertThat(statement.getBindings()).hasSize(3).containsEntry(0, SettableValue.from("before-convert"))
+				.containsEntry(1, SettableValue.from("before-save"));
+	}
+
+	@ToString
 	static class Person {
 
 		@Id String id;
 
 		@Column("THE_NAME") String name;
+
+		String description;
 
 		public String getName() {
 			return name;
@@ -261,5 +363,78 @@ public class R2dbcEntityTemplateUnitTests {
 		@Version long version;
 
 		String name;
+	}
+
+	static class ValueCapturingEntityCallback<T> {
+
+		private final List<T> values = new ArrayList<>(1);
+
+		protected void capture(T value) {
+			values.add(value);
+		}
+
+		public List<T> getValues() {
+			return values;
+		}
+
+		@Nullable
+		public T getValue() {
+			return CollectionUtils.lastElement(values);
+		}
+	}
+
+	static class ValueCapturingBeforeConvertCallback extends ValueCapturingEntityCallback<Person>
+			implements BeforeConvertCallback<Person> {
+
+		@Override
+		public Mono<Person> onBeforeConvert(Person entity, SqlIdentifier table) {
+
+			capture(entity);
+			entity.name = "before-convert";
+			return Mono.just(entity);
+		}
+	}
+
+	static class ValueCapturingBeforeSaveCallback extends ValueCapturingEntityCallback<Person>
+			implements BeforeSaveCallback<Person> {
+
+		@Override
+		public Mono<Person> onBeforeSave(Person entity, OutboundRow outboundRow, SqlIdentifier table) {
+
+			capture(entity);
+			outboundRow.put(SqlIdentifier.unquoted("description"), SettableValue.from("before-save"));
+			return Mono.just(entity);
+		}
+	}
+
+	static class ValueCapturingAfterSaveCallback extends ValueCapturingEntityCallback<Person>
+			implements AfterSaveCallback<Person> {
+
+		@Override
+		public Mono<Person> onAfterSave(Person entity, OutboundRow outboundRow, SqlIdentifier table) {
+
+			capture(entity);
+
+			Person person = new Person();
+			person.id = "after-save";
+			person.name = entity.name;
+
+			return Mono.just(person);
+		}
+	}
+
+	static class ValueCapturingAfterConvertCallback extends ValueCapturingEntityCallback<Person>
+			implements AfterConvertCallback<Person> {
+
+		@Override
+		public Mono<Person> onAfterConvert(Person entity, SqlIdentifier table) {
+
+			capture(entity);
+			Person person = new Person();
+			person.id = "after-convert";
+			person.name = entity.name;
+
+			return Mono.just(person);
+		}
 	}
 }


### PR DESCRIPTION
We now support entity callbacks for:

* `AfterConvertCallback`
* `BeforeConvertCallback`
* `BeforeSaveCallback`
* `AfterSaveCallback`

through `R2dbcEntityTemplate`.

---

Related ticket: #215.