### PR TITLE
#421 - Handle modifying query methods returning kotlin.Unit.

### DIFF
--- a/src/main/asciidoc/reference/r2dbc-repositories.adoc
+++ b/src/main/asciidoc/reference/r2dbc-repositories.adoc
@@ -267,7 +267,7 @@ Mono<Integer> setFixedFirstnameFor(String firstname, String lastname);
 
 The result of a modifying query can be:
 
-* `Void` to discard update count and await completion.
+* `Void` (or Kotlin `Unit`) to discard update count and await completion.
 * `Integer` or another numeric type emitting the affected rows count.
 * `Boolean` to emit whether at least one row was updated.
 

--- a/src/main/java/org/springframework/data/r2dbc/repository/query/AbstractR2dbcQuery.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/query/AbstractR2dbcQuery.java
@@ -15,11 +15,13 @@
  */
 package org.springframework.data.r2dbc.repository.query;
 
+import kotlin.Unit;
+
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import org.reactivestreams.Publisher;
-
+import org.springframework.core.KotlinDetector;
 import org.springframework.data.mapping.model.EntityInstantiators;
 import org.springframework.data.r2dbc.convert.R2dbcConverter;
 import org.springframework.data.r2dbc.core.DatabaseClient;
@@ -40,6 +42,7 @@ import org.springframework.util.Assert;
  * Base class for reactive {@link RepositoryQuery} implementations for R2DBC.
  *
  * @author Mark Paluch
+ * @author Stephen Cohen
  */
 public abstract class AbstractR2dbcQuery implements RepositoryQuery {
 
@@ -138,6 +141,10 @@ public abstract class AbstractR2dbcQuery implements RepositoryQuery {
 
 			if (Void.class.isAssignableFrom(returnedType.getReturnedType())) {
 				return (q, t, c) -> q.rowsUpdated().then();
+			}
+
+			if (KotlinDetector.isKotlinPresent() && Unit.class.isAssignableFrom(returnedType.getReturnedType())) {
+				return (q, t, c) -> q.rowsUpdated().thenReturn(Unit.INSTANCE);
 			}
 
 			return (q, t, c) -> q.rowsUpdated();

--- a/src/main/java/org/springframework/data/r2dbc/repository/query/R2dbcQueryMethod.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/query/R2dbcQueryMethod.java
@@ -17,9 +17,12 @@ package org.springframework.data.r2dbc.repository.query;
 
 import static org.springframework.data.repository.util.ClassUtils.*;
 
+import kotlin.Unit;
+
 import java.lang.reflect.Method;
 import java.util.Optional;
 
+import org.springframework.core.KotlinDetector;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.data.domain.Page;
@@ -51,6 +54,7 @@ import org.springframework.util.ClassUtils;
  * Reactive specific implementation of {@link QueryMethod}.
  *
  * @author Mark Paluch
+ * @author Stephen Cohen
  */
 public class R2dbcQueryMethod extends QueryMethod {
 
@@ -164,7 +168,8 @@ public class R2dbcQueryMethod extends QueryMethod {
 			Class<?> returnedObjectType = getReturnedObjectType();
 			Class<?> domainClass = getDomainClass();
 
-			if (ClassUtils.isPrimitiveOrWrapper(returnedObjectType)) {
+			if (ClassUtils.isPrimitiveOrWrapper(returnedObjectType)
+					|| KotlinDetector.isKotlinPresent() && Unit.class.isAssignableFrom(returnedObjectType)) {
 
 				this.metadata = new SimpleRelationalEntityMetadata<>((Class<Object>) domainClass,
 						mappingContext.getRequiredPersistentEntity(domainClass));

--- a/src/test/java/org/springframework/data/r2dbc/repository/query/AbstractR2dbcQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/query/AbstractR2dbcQueryUnitTests.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.repository.query;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import kotlin.Unit;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.lang.reflect.Method;
+import java.util.function.Supplier;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.projection.ProjectionFactory;
+import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
+import org.springframework.data.r2dbc.convert.MappingR2dbcConverter;
+import org.springframework.data.r2dbc.convert.R2dbcConverter;
+import org.springframework.data.r2dbc.core.DatabaseClient;
+import org.springframework.data.r2dbc.core.FetchSpec;
+import org.springframework.data.r2dbc.mapping.R2dbcMappingContext;
+import org.springframework.data.r2dbc.repository.Modifying;
+import org.springframework.data.relational.core.mapping.Table;
+import org.springframework.data.relational.repository.query.RelationalParameterAccessor;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.core.RepositoryMetadata;
+import org.springframework.data.repository.core.support.AbstractRepositoryMetadata;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Unit tests for {@link AbstractR2dbcQuery}
+ *
+ * @author Stephen Cohen
+ */
+@RunWith(MockitoJUnitRunner.StrictStubs.class)
+public class AbstractR2dbcQueryUnitTests {
+
+	@Mock(stubOnly = true) private DatabaseClient mockDatabaseClient;
+	@Mock(stubOnly = true) private DatabaseClient.GenericExecuteSpec mockGenericExecuteSpec;
+	@Mock(stubOnly = true) private DatabaseClient.TypedExecuteSpec<Object> mockTypedExecuteSpec;
+	@Mock(stubOnly = true) private FetchSpec<Object> mockFetchSpec;
+
+	private final MappingR2dbcConverter converter = new MappingR2dbcConverter(new R2dbcMappingContext());
+	private final RepositoryMetadata repositoryMetadata = AbstractRepositoryMetadata.getMetadata(TestRepository.class);
+	private final ProjectionFactory projectionFactory = new SpelAwareProxyProjectionFactory();
+
+	@Before
+	public void setUpMocks() {
+
+		when(mockDatabaseClient.execute(Mockito.<Supplier<String>>any())).thenReturn(mockGenericExecuteSpec);
+
+		when(mockGenericExecuteSpec.as(any())).thenReturn(mockTypedExecuteSpec);
+
+		when(mockTypedExecuteSpec.fetch()).thenReturn(mockFetchSpec);
+	}
+
+	private R2dbcQueryMethod getQueryMethod(final String name) {
+
+		final Method method = ReflectionUtils.findMethod(TestRepository.class, name, new Class<?>[0]);
+		return new R2dbcQueryMethod(method, repositoryMetadata, projectionFactory, converter.getMappingContext());
+	}
+
+	private DummyR2dbcQuery makeQuery(final String methodName) {
+		return new DummyR2dbcQuery(getQueryMethod(methodName), mockDatabaseClient, converter);
+	}
+
+	@Test // gh-421
+	public void shouldExecuteFindReturningOneEntity() {
+
+		final DummyR2dbcQuery query = makeQuery("findOne");
+		final TestEntity entity = new TestEntity(1, "test");
+
+		when(mockFetchSpec.one()).thenReturn(Mono.just(entity));
+
+		final Object result = query.execute(new Object[0]);
+
+		assertThat(result).isInstanceOf(Mono.class);
+
+		@SuppressWarnings("unchecked")
+		final Mono<Object> resultMono = (Mono<Object>) result;
+
+		resultMono.as(StepVerifier::create) //
+				.expectNext(entity) //
+				.verifyComplete();
+	}
+
+	@Test // gh-421
+	public void shouldExecuteFindReturningManyEntities() {
+
+		final DummyR2dbcQuery query = makeQuery("findMany");
+		final TestEntity[] entities = new TestEntity[] {
+				new TestEntity(1, "test1"),
+				new TestEntity(2, "test2")
+		};
+
+		when(mockFetchSpec.all()).thenReturn(Flux.fromArray(entities));
+
+		final Object result = query.execute(new Object[0]);
+
+		assertThat(result).isInstanceOf(Flux.class);
+
+		@SuppressWarnings("unchecked")
+		final Flux<Object> resultFlux = (Flux<Object>) result;
+
+		resultFlux.collectList() //
+				.as(StepVerifier::create) //
+				.assertNext(results -> assertThat(results).containsExactlyInAnyOrder(entities)) //
+				.verifyComplete();
+	}
+
+	@Test // gh-421
+	public void shouldExecuteModifyingQueryReturningSuccessBoolean() {
+
+		final DummyR2dbcQuery query = makeQuery("modifyAndReturnSuccessBoolean");
+
+		when(mockFetchSpec.rowsUpdated()).thenReturn(Mono.just(1));
+
+		final Object result = query.execute(new Object[0]);
+
+		assertThat(result).isInstanceOf(Mono.class);
+
+		@SuppressWarnings("unchecked")
+		final Mono<Object> resultMono = (Mono<Object>) result;
+
+		resultMono.as(StepVerifier::create) //
+				.expectNext(true) //
+				.verifyComplete();
+	}
+
+	@Test // gh-421
+	public void shouldExecuteModifyingQueryReturningFailureBoolean() {
+
+		final DummyR2dbcQuery query = makeQuery("modifyAndReturnSuccessBoolean");
+
+		when(mockFetchSpec.rowsUpdated()).thenReturn(Mono.just(0));
+
+		final Object result = query.execute(new Object[0]);
+
+		assertThat(result).isInstanceOf(Mono.class);
+
+		@SuppressWarnings("unchecked")
+		final Mono<Object> resultMono = (Mono<Object>) result;
+
+		resultMono.as(StepVerifier::create) //
+				.expectNext(false) //
+				.verifyComplete();
+	}
+
+	@Test // gh-421
+	public void shouldExecuteModifyingQueryReturningAffectedRowCount() {
+
+		final DummyR2dbcQuery query = makeQuery("modifyAndReturnAffectedRowCount");
+
+		when(mockFetchSpec.rowsUpdated()).thenReturn(Mono.just(42));
+
+		final Object result = query.execute(new Object[0]);
+
+		assertThat(result).isInstanceOf(Mono.class);
+
+		@SuppressWarnings("unchecked")
+		final Mono<Object> resultMono = (Mono<Object>) result;
+
+		resultMono.as(StepVerifier::create) //
+				.expectNext(42) //
+				.verifyComplete();
+	}
+
+	@Test // gh-421
+	public void shouldExecuteModifyingQueryReturningVoid() {
+
+		final DummyR2dbcQuery query = makeQuery("modifyAndReturnVoid");
+
+		when(mockFetchSpec.rowsUpdated()).thenReturn(Mono.just(42));
+
+		final Object result = query.execute(new Object[0]);
+
+		assertThat(result).isInstanceOf(Mono.class);
+
+		@SuppressWarnings("unchecked")
+		final Mono<Object> resultMono = (Mono<Object>) result;
+
+		resultMono.as(StepVerifier::create).verifyComplete();
+	}
+
+	@Test // gh-421
+	public void shouldExecuteModifyingQueryReturningKotlinUnit() {
+
+		final DummyR2dbcQuery query = makeQuery("modifyAndReturnKotlinUnit");
+
+		when(mockFetchSpec.rowsUpdated()).thenReturn(Mono.just(42));
+
+		final Object result = query.execute(new Object[0]);
+
+		assertThat(result).isInstanceOf(Mono.class);
+
+		@SuppressWarnings("unchecked")
+		final Mono<Object> resultMono = (Mono<Object>) result;
+
+		resultMono.as(StepVerifier::create) //
+				.expectNext(Unit.INSTANCE) //
+				.verifyComplete();
+	}
+
+	private static class DummyR2dbcQuery extends AbstractR2dbcQuery {
+
+		public DummyR2dbcQuery(final R2dbcQueryMethod method, final DatabaseClient databaseClient,
+				final R2dbcConverter converter) {
+			super(method, databaseClient, converter);
+		}
+
+		@Override
+		protected boolean isModifyingQuery() {
+			return getQueryMethod().isModifyingQuery();
+		}
+
+		@Override
+		protected BindableQuery createQuery(final RelationalParameterAccessor accessor) {
+
+			return new BindableQuery() {
+
+				@Override
+				public <T extends DatabaseClient.BindSpec<T>> T bind(final T bindSpec) {
+					return bindSpec;
+				}
+
+				@Override
+				public String get() {
+					return "testQuery";
+				}
+			};
+		}
+	}
+
+	@SuppressWarnings("unused")
+	private interface TestRepository extends Repository<TestEntity, Integer> {
+
+		Mono<TestEntity> findOne();
+
+		Flux<TestEntity> findMany();
+
+		@Modifying
+		Mono<Boolean> modifyAndReturnSuccessBoolean();
+
+		@Modifying
+		Mono<Integer> modifyAndReturnAffectedRowCount();
+
+		@Modifying
+		Mono<Void> modifyAndReturnVoid();
+
+		@Modifying
+		Mono<Unit> modifyAndReturnKotlinUnit();
+	}
+
+	@Table
+	private static class TestEntity {
+
+		@Id private final Integer id;
+		private final String data;
+
+		public TestEntity(final Integer id, final String data) {
+
+			this.id = id;
+			this.data = data;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getData() {
+			return data;
+		}
+
+		@Override
+		public boolean equals(final Object other) {
+
+			if (!(other instanceof TestEntity)) {
+				return false;
+			}
+
+			final TestEntity otherTestEntity = (TestEntity) other;
+
+			return this.id.equals(otherTestEntity.id) && this.data.equals(otherTestEntity.data);
+		}
+	}
+}

--- a/src/test/java/org/springframework/data/r2dbc/repository/query/R2dbcQueryMethodUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/query/R2dbcQueryMethodUnitTests.java
@@ -17,6 +17,8 @@ package org.springframework.data.r2dbc.repository.query;
 
 import static org.assertj.core.api.Assertions.*;
 
+import kotlin.Unit;
+
 import reactor.core.publisher.Mono;
 
 import java.lang.annotation.Retention;
@@ -45,6 +47,7 @@ import org.springframework.data.repository.core.support.DefaultRepositoryMetadat
  * Unit test for {@link R2dbcQueryMethod}.
  *
  * @author Mark Paluch
+ * @author Stephen Cohen
  */
 public class R2dbcQueryMethodUnitTests {
 
@@ -128,6 +131,14 @@ public class R2dbcQueryMethodUnitTests {
 		assertThat(method.getEntityInformation().getJavaType()).isAssignableFrom(Contact.class);
 	}
 
+	@Test // gh-421
+	public void fallsBackToRepositoryDomainTypeIfMethodReturnsKotlinUnit() throws Exception {
+
+		R2dbcQueryMethod method = queryMethod(PersonRepository.class, "deleteByFirstname", String.class);
+
+		assertThat(method.getEntityInformation().getJavaType()).isAssignableFrom(Contact.class);
+	}
+
 	private R2dbcQueryMethod queryMethod(Class<?> repository, String name, Class<?>... parameters) throws Exception {
 
 		Method method = repository.getMethod(name, parameters);
@@ -144,6 +155,8 @@ public class R2dbcQueryMethodUnitTests {
 		Mono<Slice<Contact>> findMonoSliceByLastname(String lastname, Pageable pageRequest);
 
 		void deleteByUserName(String userName);
+
+		Unit deleteByFirstname(String firstname);
 	}
 
 	interface SampleRepository extends Repository<Contact, Long> {


### PR DESCRIPTION
Added check for `kotlin.Unit` to `AbstractR2dbcQuery#getExecutionToWrap`. This case is essentially equivalent to a return type of `Void`, but the singleton `Unit` instance needs to be returned instead of discarding the result entirely.

It was also necessary to add a check to `R2dbcQueryMethod#getEntityInformation`, as otherwise a `PersistentEntity` is created for `Unit`, which leads to a _new_ instance being created via reflection down the pipeline (which is probably not a thing that should happen).

Added `AbstractR2dbcQueryUnitTests` to test the functionality surrounding the main change. Also added integration tests surrounding modifying query return types.

A couple notes:
* While I do believe the check added to `R2dbcQueryMethod#getEntityInformation` is sufficient to prevent a `PersistentEntity` or new instance of `Unit` from being created for this particular case, I feel like it might be a good idea to add an additional check for `Unit` to `SimpleTypeHolder`, [alongside the one for `java.lang.*`](https://github.com/spring-projects/spring-data-commons/blob/master/src/main/java/org/springframework/data/mapping/model/SimpleTypeHolder.java#L159). I'm not sure whether there's a need for a broader `kotlin.*` check, though.
* I'm not exactly thrilled about the idea of peppering `KotlinDetector.isKotlinPresent() && Unit.class.isAssignableFrom(someClass)` all over the place. I don't think a check for `Unit` belongs in `ClassUtils.isPrimitiveOrWrapper` as, strictly speaking, `Unit` is neither of those, but perhaps an `isKotlinUnit(Class)` method could be added to `KotlinDetector`.

(I decided to submit this PR without either of those improvements since those are both in other repos and the solution works as-is for now. I'd like to know your thoughts on this PR and those/any other potential improvements before I go submitting any additional PRs elsewhere.)