### PR TITLE
Fix typos in reference docs

### DIFF
--- a/src/main/asciidoc/reference/r2dbc-repositories.adoc
+++ b/src/main/asciidoc/reference/r2dbc-repositories.adoc
@@ -368,9 +368,9 @@ Person other = template.select(Person.class)
 				.first().block();                                                     <2>
 
 daenerys.setLastname("Targaryen");
-template.save(daenerys);                                                              <3>
+template.update(daenerys);                                                            <3>
 
-template.save(other).subscribe(); // emits OptimisticLockingFailureException          <4>
+template.update(other).subscribe(); // emits OptimisticLockingFailureException        <4>
 ----
 <1> Initially insert row. `version` is set to `0`.
 <2> Load the just inserted row. `version` is still `0`.


### PR DESCRIPTION
Hello, I found typos in the reference documentation, so I fixed it.
I think this method name is `update`.

https://github.com/spring-projects/spring-data-r2dbc/blob/master/src/main/java/org/springframework/data/r2dbc/core/R2dbcEntityTemplate.java