### PR TITLE
Remove .RELEASE suffix from version number in documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -80,7 +80,7 @@ Add the Maven dependency:
 <dependency>
   <groupId>org.springframework.data</groupId>
   <artifactId>spring-data-r2dbc</artifactId>
-  <version>${version}.RELEASE</version>
+  <version>${version}</version>
 </dependency>
 ----
 


### PR DESCRIPTION
Updates the readme to just say `${version}` when specifying the r2dbc dependency.

Looks like in versions `1.2.x` [the `RELEASE` suffix is no longer used](https://mvnrepository.com/artifact/org.springframework.data/spring-data-r2dbc), so I think it would be more clear to just say `${version}`.