### PR TITLE
Fixed flaky tests resulting from getDeclaredFields method used in a dependency. This causes the order of the fields returned by preparedOperation to be non-deterministic.

### DIFF
--- a/src/test/java/org/springframework/data/r2dbc/repository/query/PartTreeR2dbcQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/query/PartTreeR2dbcQueryUnitTests.java
@@ -27,6 +27,8 @@ import reactor.core.publisher.Mono;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
+import java.util.ArrayList;
 import java.util.Date;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -108,8 +110,8 @@ class PartTreeR2dbcQueryUnitTests {
 				dataAccessStrategy);
 		PreparedOperation<?> preparedOperation = createQuery(queryMethod, r2dbcQuery, "John");
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".first_name = $1");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".first_name = $1"));
 	}
 
 	@Test // gh-282
@@ -120,8 +122,8 @@ class PartTreeR2dbcQueryUnitTests {
 				dataAccessStrategy);
 		PreparedOperation<?> preparedOperation = createQuery(queryMethod, r2dbcQuery, new Object[] { null });
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".first_name IS NULL");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".first_name IS NULL"));
 	}
 
 	@Test // gh-282
@@ -145,8 +147,8 @@ class PartTreeR2dbcQueryUnitTests {
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery,
 				getAccessor(queryMethod, new Object[] { "Doe", "John" }));
 
-		assertThat(preparedOperation.get()).isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE
-				+ ".last_name = $1 AND (" + TABLE + ".first_name = $2)");
+		assertThat(formatOperation(preparedOperation)).isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE
+				+ ".last_name = $1 AND (" + TABLE + ".first_name = $2)"));
 	}
 
 	@Test // gh-282
@@ -158,8 +160,8 @@ class PartTreeR2dbcQueryUnitTests {
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery,
 				getAccessor(queryMethod, new Object[] { "Doe", "John" }));
 
-		assertThat(preparedOperation.get()).isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE
-				+ ".last_name = $1 OR (" + TABLE + ".first_name = $2)");
+		assertThat(formatOperation(preparedOperation)).isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE
+				+ ".last_name = $1 OR (" + TABLE + ".first_name = $2)"));
 	}
 
 	@Test // gh-282, gh-349
@@ -173,8 +175,8 @@ class PartTreeR2dbcQueryUnitTests {
 		RelationalParametersParameterAccessor accessor = getAccessor(queryMethod, new Object[] { from, to });
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".date_of_birth BETWEEN $1 AND $2");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".date_of_birth BETWEEN $1 AND $2"));
 
 		BindTarget bindTarget = mock(BindTarget.class);
 		preparedOperation.bindTo(bindTarget);
@@ -192,8 +194,8 @@ class PartTreeR2dbcQueryUnitTests {
 		RelationalParametersParameterAccessor accessor = getAccessor(queryMethod, new Object[] { 30 });
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".age < $1");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".age < $1"));
 	}
 
 	@Test // gh-282
@@ -205,8 +207,8 @@ class PartTreeR2dbcQueryUnitTests {
 		RelationalParametersParameterAccessor accessor = getAccessor(queryMethod, new Object[] { 30 });
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".age <= $1");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".age <= $1"));
 	}
 
 	@Test // gh-282
@@ -218,8 +220,8 @@ class PartTreeR2dbcQueryUnitTests {
 		RelationalParametersParameterAccessor accessor = getAccessor(queryMethod, new Object[] { 30 });
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".age > $1");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".age > $1"));
 	}
 
 	@Test // gh-282
@@ -231,8 +233,8 @@ class PartTreeR2dbcQueryUnitTests {
 		RelationalParametersParameterAccessor accessor = getAccessor(queryMethod, new Object[] { 30 });
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".age >= $1");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".age >= $1"));
 	}
 
 	@Test // gh-282
@@ -244,8 +246,8 @@ class PartTreeR2dbcQueryUnitTests {
 		RelationalParametersParameterAccessor accessor = getAccessor(queryMethod, new Object[] { new Date() });
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".date_of_birth > $1");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".date_of_birth > $1"));
 	}
 
 	@Test // gh-282
@@ -256,8 +258,8 @@ class PartTreeR2dbcQueryUnitTests {
 		RelationalParametersParameterAccessor accessor = getAccessor(queryMethod, new Object[] { new Date() });
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".date_of_birth < $1");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".date_of_birth < $1"));
 	}
 
 	@Test // gh-282
@@ -269,8 +271,8 @@ class PartTreeR2dbcQueryUnitTests {
 		RelationalParametersParameterAccessor accessor = getAccessor(queryMethod, new Object[0]);
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".age IS NULL");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".age IS NULL"));
 	}
 
 	@Test // gh-282
@@ -282,8 +284,8 @@ class PartTreeR2dbcQueryUnitTests {
 		RelationalParametersParameterAccessor accessor = getAccessor(queryMethod, new Object[0]);
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".age IS NOT NULL");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".age IS NOT NULL"));
 	}
 
 	@Test // gh-282
@@ -295,8 +297,8 @@ class PartTreeR2dbcQueryUnitTests {
 		RelationalParametersParameterAccessor accessor = getAccessor(queryMethod, new Object[] { "%John%" });
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".first_name LIKE $1");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".first_name LIKE $1"));
 	}
 
 	@Test // gh-282
@@ -308,8 +310,8 @@ class PartTreeR2dbcQueryUnitTests {
 		RelationalParametersParameterAccessor accessor = getAccessor(queryMethod, new Object[] { "%John%" });
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".first_name NOT LIKE $1");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".first_name NOT LIKE $1"));
 	}
 
 	@Test // gh-282
@@ -321,8 +323,8 @@ class PartTreeR2dbcQueryUnitTests {
 		RelationalParametersParameterAccessor accessor = getAccessor(queryMethod, new Object[] { "Jo" });
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".first_name LIKE $1");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".first_name LIKE $1"));
 	}
 
 	@Test // gh-282
@@ -348,8 +350,8 @@ class PartTreeR2dbcQueryUnitTests {
 		RelationalParametersParameterAccessor accessor = getAccessor(queryMethod, new Object[] { "hn" });
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".first_name LIKE $1");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".first_name LIKE $1"));
 	}
 
 	@Test // gh-282
@@ -375,8 +377,8 @@ class PartTreeR2dbcQueryUnitTests {
 		RelationalParametersParameterAccessor accessor = getAccessor(queryMethod, new Object[] { "oh" });
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".first_name LIKE $1");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".first_name LIKE $1"));
 	}
 
 	@Test // gh-282
@@ -402,8 +404,8 @@ class PartTreeR2dbcQueryUnitTests {
 		RelationalParametersParameterAccessor accessor = getAccessor(queryMethod, new Object[] { "oh" });
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".first_name NOT LIKE $1");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".first_name NOT LIKE $1"));
 	}
 
 	@Test // gh-282
@@ -429,9 +431,9 @@ class PartTreeR2dbcQueryUnitTests {
 		RelationalParametersParameterAccessor accessor = getAccessor(queryMethod, new Object[] { "oh" });
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
+		assertThat(formatOperation(preparedOperation))
 				.isEqualTo(
-						"SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".age = $1 ORDER BY users.last_name DESC");
+						formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".age = $1 ORDER BY users.last_name DESC"));
 	}
 
 	@Test // gh-282
@@ -442,9 +444,9 @@ class PartTreeR2dbcQueryUnitTests {
 		RelationalParametersParameterAccessor accessor = getAccessor(queryMethod, new Object[] { "oh" });
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
+		assertThat(formatOperation(preparedOperation))
 				.isEqualTo(
-						"SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".age = $1 ORDER BY users.last_name ASC");
+						formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".age = $1 ORDER BY users.last_name ASC"));
 	}
 
 	@Test // gh-282
@@ -455,8 +457,8 @@ class PartTreeR2dbcQueryUnitTests {
 		RelationalParametersParameterAccessor accessor = getAccessor(queryMethod, new Object[] { "Doe" });
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".last_name != $1");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".last_name != $1"));
 	}
 
 	@Test // gh-282
@@ -469,8 +471,8 @@ class PartTreeR2dbcQueryUnitTests {
 				new Object[] { Collections.singleton(25) });
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".age IN ($1)");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".age IN ($1)"));
 	}
 
 	@Test // gh-282
@@ -482,8 +484,8 @@ class PartTreeR2dbcQueryUnitTests {
 				new Object[] { Collections.singleton(25) });
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".age NOT IN ($1)");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".age NOT IN ($1)"));
 	}
 
 	@Test // gh-282
@@ -495,8 +497,8 @@ class PartTreeR2dbcQueryUnitTests {
 		RelationalParametersParameterAccessor accessor = getAccessor(queryMethod, new Object[0]);
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".active = TRUE");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".active = TRUE"));
 	}
 
 	@Test // gh-282
@@ -508,8 +510,8 @@ class PartTreeR2dbcQueryUnitTests {
 		RelationalParametersParameterAccessor accessor = getAccessor(queryMethod, new Object[0]);
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".active = FALSE");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".active = FALSE"));
 	}
 
 	@Test // gh-282
@@ -521,8 +523,8 @@ class PartTreeR2dbcQueryUnitTests {
 		RelationalParametersParameterAccessor accessor = getAccessor(queryMethod, new Object[] { "John" });
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE UPPER(" + TABLE + ".first_name) = UPPER($1)");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE UPPER(" + TABLE + ".first_name) = UPPER($1)"));
 	}
 
 	@Test // gh-282
@@ -585,8 +587,8 @@ class PartTreeR2dbcQueryUnitTests {
 		RelationalParametersParameterAccessor accessor = getAccessor(queryMethod, new Object[] { "John" });
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".first_name = $1 LIMIT 3");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".first_name = $1 LIMIT 3"));
 	}
 
 	@Test // gh-282
@@ -598,8 +600,8 @@ class PartTreeR2dbcQueryUnitTests {
 		RelationalParametersParameterAccessor accessor = getAccessor(queryMethod, new Object[] { "John" });
 		PreparedOperation<?> preparedOperation = createQuery(r2dbcQuery, accessor);
 
-		assertThat(preparedOperation.get())
-				.isEqualTo("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".first_name = $1 LIMIT 1");
+		assertThat(formatOperation(preparedOperation))
+				.isEqualTo(formatQuery("SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".first_name = $1 LIMIT 1"));
 	}
 
 	@Test // gh-341
@@ -622,8 +624,8 @@ class PartTreeR2dbcQueryUnitTests {
 				dataAccessStrategy);
 		PreparedOperation<?> preparedOperation = createQuery(queryMethod, r2dbcQuery, "John");
 
-		assertThat(preparedOperation.get()).isEqualTo("SELECT " + DISTINCT + " " + TABLE + ".first_name, " + TABLE
-				+ ".foo FROM " + TABLE + " WHERE " + TABLE + ".first_name = $1");
+		assertThat(formatOperation(preparedOperation)).isEqualTo(formatQuery("SELECT " + DISTINCT + " " + TABLE + ".first_name, " + TABLE
+				+ ".foo FROM " + TABLE + " WHERE " + TABLE + ".first_name = $1"));
 	}
 
 	@Test // gh-475
@@ -634,9 +636,9 @@ class PartTreeR2dbcQueryUnitTests {
 				dataAccessStrategy);
 		PreparedOperation<?> preparedOperation = createQuery(queryMethod, r2dbcQuery);
 
-		assertThat(preparedOperation.get()).isEqualTo(
-				"SELECT users.id, users.first_name, users.last_name, users.date_of_birth, users.age, users.active FROM "
-						+ TABLE);
+		assertThat(formatOperation(preparedOperation)).isEqualTo(
+				formatQuery("SELECT users.id, users.first_name, users.last_name, users.date_of_birth, users.age, users.active FROM "
+						+ TABLE));
 	}
 
 	@Test // gh-475
@@ -647,9 +649,9 @@ class PartTreeR2dbcQueryUnitTests {
 				dataAccessStrategy);
 		PreparedOperation<?> preparedOperation = createQuery(queryMethod, r2dbcQuery);
 
-		assertThat(preparedOperation.get()).isEqualTo(
-				"SELECT users.id, users.first_name, users.last_name, users.date_of_birth, users.age, users.active FROM "
-						+ TABLE);
+		assertThat(formatOperation(preparedOperation)).isEqualTo(
+				formatQuery("SELECT users.id, users.first_name, users.last_name, users.date_of_birth, users.age, users.active FROM "
+						+ TABLE));
 	}
 
 	@Test // gh-363
@@ -681,8 +683,62 @@ class PartTreeR2dbcQueryUnitTests {
 	}
 
 	private RelationalParametersParameterAccessor getAccessor(R2dbcQueryMethod queryMethod, Object[] values) {
-		return new RelationalParametersParameterAccessor(queryMethod, values);
+	    	return new RelationalParametersParameterAccessor(queryMethod, values);
 	}
+
+	private static String formatOperation(PreparedOperation<?> preparedOperation){
+         	return formatQuery(preparedOperation.get());
+	}
+
+	private static String formatQuery(String query){
+                String firstKeyword = "SELECT";
+                String lastKeyword = "FROM";
+
+                int indexOfFirstKeyWord = query.toUpperCase().indexOf(firstKeyword);
+                int indexOfLastKeyWord = query.toUpperCase().indexOf(lastKeyword);
+
+                if(indexOfFirstKeyWord!=0 || indexOfFirstKeyWord>=indexOfLastKeyWord){
+                        return query;
+                }
+
+                String fields = query.substring(firstKeyword.length(), indexOfLastKeyWord);
+                String sortedFields = sortFields(fields);
+
+                StringBuilder formattedQuery = new StringBuilder();
+                formattedQuery.append(firstKeyword);
+                formattedQuery.append(" ");
+                formattedQuery.append(sortedFields);
+                formattedQuery.append(" ");
+                formattedQuery.append(query.substring(indexOfLastKeyWord, query.length()));
+
+                return formattedQuery.toString();
+        }
+
+        private static String sortFields(String fields){
+                List<String> sortedFieldsList = new ArrayList<>();
+                StringBuilder fieldBuilder = new StringBuilder();
+                StringBuilder sortedFields = new StringBuilder();
+
+                for(int i=0;i<fields.length();i++){
+                        if(fields.charAt(i)==','){
+                                sortedFieldsList.add(fieldBuilder.toString().trim());
+                                fieldBuilder = new StringBuilder();
+                        }else{
+                                fieldBuilder.append(fields.charAt(i));
+                        }
+                }
+                sortedFieldsList.add(fieldBuilder.toString().trim());
+                Collections.sort(sortedFieldsList);
+
+                for(String sortedField: sortedFieldsList){
+                        if(sortedFieldsList.get(0)!=sortedField){
+                                sortedFields.append(", ");
+                        }
+                        sortedFields.append(sortedField);
+                }
+
+                return sortedFields.toString();
+        }
 
 	@SuppressWarnings("ALL")
 	interface UserRepository extends Repository<User, Long> {
@@ -767,7 +823,7 @@ class PartTreeR2dbcQueryUnitTests {
 	@Table("users")
 	@Data
 	private static class User {
-
+	
 		private @Id Long id;
 		private String firstName;
 		private String lastName;

--- a/src/test/java/org/springframework/data/r2dbc/repository/query/PartTreeR2dbcQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/query/PartTreeR2dbcQueryUnitTests.java
@@ -66,6 +66,7 @@ import org.springframework.r2dbc.core.binding.BindTarget;
  * @author Mark Paluch
  * @author Mingyuan Wu
  * @author Myeonghyeon Lee
+ * @author Philmon Roberts
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -683,61 +684,60 @@ class PartTreeR2dbcQueryUnitTests {
 	}
 
 	private RelationalParametersParameterAccessor getAccessor(R2dbcQueryMethod queryMethod, Object[] values) {
-	    	return new RelationalParametersParameterAccessor(queryMethod, values);
+		return new RelationalParametersParameterAccessor(queryMethod, values);
 	}
 
 	private static String formatOperation(PreparedOperation<?> preparedOperation){
-         	return formatQuery(preparedOperation.get());
+		return formatQuery(preparedOperation.get());
 	}
 
 	private static String formatQuery(String query){
-                String firstKeyword = "SELECT";
-                String lastKeyword = "FROM";
-
-                int indexOfFirstKeyWord = query.toUpperCase().indexOf(firstKeyword);
-                int indexOfLastKeyWord = query.toUpperCase().indexOf(lastKeyword);
-
-                if(indexOfFirstKeyWord!=0 || indexOfFirstKeyWord>=indexOfLastKeyWord){
-                        return query;
-                }
-
-                String fields = query.substring(firstKeyword.length(), indexOfLastKeyWord);
-                String sortedFields = sortFields(fields);
-
-                StringBuilder formattedQuery = new StringBuilder();
-                formattedQuery.append(firstKeyword);
-                formattedQuery.append(" ");
-                formattedQuery.append(sortedFields);
-                formattedQuery.append(" ");
-                formattedQuery.append(query.substring(indexOfLastKeyWord, query.length()));
-
-                return formattedQuery.toString();
+		String firstKeyword = "SELECT";
+		String lastKeyword = "FROM";
+		
+		int indexOfFirstKeyWord = query.toUpperCase().indexOf(firstKeyword);
+		int indexOfLastKeyWord = query.toUpperCase().indexOf(lastKeyword);
+		
+		if(indexOfFirstKeyWord!=0 || indexOfFirstKeyWord>=indexOfLastKeyWord){
+			return query;
+		}
+		
+		String fields = query.substring(firstKeyword.length(), indexOfLastKeyWord);
+		String sortedFields = sortFields(fields);
+		
+		StringBuilder formattedQuery = new StringBuilder();
+		formattedQuery.append(firstKeyword);
+		formattedQuery.append(" ");
+		formattedQuery.append(sortedFields);
+		formattedQuery.append(" ");
+		formattedQuery.append(query.substring(indexOfLastKeyWord, query.length()));
+		
+		return formattedQuery.toString();
         }
 
         private static String sortFields(String fields){
-                List<String> sortedFieldsList = new ArrayList<>();
-                StringBuilder fieldBuilder = new StringBuilder();
-                StringBuilder sortedFields = new StringBuilder();
-
-                for(int i=0;i<fields.length();i++){
-                        if(fields.charAt(i)==','){
-                                sortedFieldsList.add(fieldBuilder.toString().trim());
-                                fieldBuilder = new StringBuilder();
-                        }else{
-                                fieldBuilder.append(fields.charAt(i));
-                        }
-                }
-                sortedFieldsList.add(fieldBuilder.toString().trim());
-                Collections.sort(sortedFieldsList);
-
-                for(String sortedField: sortedFieldsList){
-                        if(sortedFieldsList.get(0)!=sortedField){
-                                sortedFields.append(", ");
-                        }
-                        sortedFields.append(sortedField);
-                }
-
-                return sortedFields.toString();
+		List<String> sortedFieldsList = new ArrayList<>();
+		StringBuilder fieldBuilder = new StringBuilder();
+		StringBuilder sortedFields = new StringBuilder();
+		
+		for(int i=0;i<fields.length();i++){
+			if(fields.charAt(i)==','){
+				sortedFieldsList.add(fieldBuilder.toString().trim());
+				fieldBuilder = new StringBuilder();
+			}else{
+				fieldBuilder.append(fields.charAt(i));
+			}
+		}
+		sortedFieldsList.add(fieldBuilder.toString().trim());
+		Collections.sort(sortedFieldsList);
+		
+		for(String sortedField: sortedFieldsList){
+			if(sortedFieldsList.get(0)!=sortedField){
+				sortedFields.append(", ");
+			}
+			sortedFields.append(sortedField);
+		}
+		return sortedFields.toString();
         }
 
 	@SuppressWarnings("ALL")
@@ -823,7 +823,7 @@ class PartTreeR2dbcQueryUnitTests {
 	@Table("users")
 	@Data
 	private static class User {
-	
+		
 		private @Id Long id;
 		private String firstName;
 		private String lastName;

--- a/src/test/java/org/springframework/data/r2dbc/repository/query/PartTreeR2dbcQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/query/PartTreeR2dbcQueryUnitTests.java
@@ -823,7 +823,7 @@ class PartTreeR2dbcQueryUnitTests {
 	@Table("users")
 	@Data
 	private static class User {
-		
+
 		private @Id Long id;
 		private String firstName;
 		private String lastName;


### PR DESCRIPTION
This PR fixes the flaky tests that results when `preparedOperation.get()` is compared to an expected query string, say for example, `"SELECT " + ALL_FIELDS + " FROM " + TABLE + " WHERE " + TABLE + ".first_name = $1"`. The assumption is that `preparedOperation.get()` returns the field names in the exact order  `ALL_FIELDS` is declared with. However, this is not the case. To be more specific, the the field names returned by `preparedOperation.get()` can be in any of the n! orders, where n is the number of fields querying for. This non-deterministic behavior is due to the `getDeclaredFields()` method called in one of your dependencies (`org.springframework.util.ReflectionUtils`). And as specified by the javaDocs for `getDeclaredFields()`, _The elements in the returned array are not sorted and are not in any particular order_.

My fix is to sort the fields for both the expected and actual query strings prior to checking whether they are equal. I, however, excluded applying this fix to cases where only one field was queried because 1!=1, and so those tests are deterministic.

<br />

Declaration:
- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
