### PR TITLE
Introduced pessimistic locks for derived queries.

### DIFF
--- a/src/main/java/org/springframework/data/r2dbc/core/DefaultStatementMapper.java
+++ b/src/main/java/org/springframework/data/r2dbc/core/DefaultStatementMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ import org.springframework.util.Assert;
  * @author Mark Paluch
  * @author Roman Chigvintsev
  * @author Mingyuan Wu
+ * @author Diego Krupitza
  */
 class DefaultStatementMapper implements StatementMapper {
 
@@ -129,6 +130,10 @@ class DefaultStatementMapper implements StatementMapper {
 
 		if (selectSpec.getOffset() > 0) {
 			selectBuilder.offset(selectSpec.getOffset());
+		}
+
+		if (selectSpec.getLock() != null) {
+			selectBuilder.lock(selectSpec.getLock());
 		}
 
 		Select select = selectBuilder.build();

--- a/src/main/java/org/springframework/data/r2dbc/dialect/H2Dialect.java
+++ b/src/main/java/org/springframework/data/r2dbc/dialect/H2Dialect.java
@@ -1,5 +1,7 @@
 package org.springframework.data.r2dbc.dialect;
 
+import org.springframework.data.relational.core.dialect.AnsiDialect;
+import org.springframework.data.relational.core.dialect.LockClause;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
 
 /**
@@ -7,6 +9,7 @@ import org.springframework.data.relational.core.sql.SqlIdentifier;
  *
  * @author Mark Paluch
  * @author Jens Schauder
+ * @author Diego Krupitza
  */
 public class H2Dialect extends PostgresDialect {
 
@@ -19,4 +22,17 @@ public class H2Dialect extends PostgresDialect {
 	public String renderForGeneratedValues(SqlIdentifier identifier) {
 		return identifier.getReference(getIdentifierProcessing());
 	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.relational.core.dialect.Dialect#lock()
+	 */
+	@Override
+	public LockClause lock() {
+		// H2 Dialect does not support the same lock keywords as PostgreSQL, but it supports the ANSI SQL standard.
+		// see https://www.h2database.com/html/commands.html
+		// and https://www.h2database.com/html/features.html#compatibility
+		return AnsiDialect.INSTANCE.lock();
+	}
+
 }

--- a/src/main/java/org/springframework/data/r2dbc/repository/Lock.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/Lock.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.r2dbc.repository;
+
+import org.springframework.data.annotation.QueryAnnotation;
+import org.springframework.data.relational.core.sql.LockMode;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotation to provide a lock mode for a given query.
+ *
+ * @author Diego Krupitza
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@QueryAnnotation
+@Documented
+public @interface Lock {
+
+	/**
+	 * Defines which type of {@link LockMode} we want to use.
+	 */
+	LockMode value();
+
+}

--- a/src/main/java/org/springframework/data/r2dbc/repository/query/PartTreeR2dbcQuery.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/query/PartTreeR2dbcQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import org.springframework.r2dbc.core.PreparedOperation;
  *
  * @author Roman Chigvintsev
  * @author Mark Paluch
+ * @author Diego Krupitza
  * @since 1.1
  */
 public class PartTreeR2dbcQuery extends AbstractR2dbcQuery {
@@ -119,7 +120,7 @@ public class PartTreeR2dbcQuery extends AbstractR2dbcQuery {
 
 			RelationalEntityMetadata<?> entityMetadata = getQueryMethod().getEntityInformation();
 			R2dbcQueryCreator queryCreator = new R2dbcQueryCreator(tree, dataAccessStrategy, entityMetadata, accessor,
-					projectedProperties);
+					projectedProperties, this.getQueryMethod().getLock());
 			return queryCreator.createQuery(getDynamicSort(accessor));
 		});
 	}

--- a/src/main/java/org/springframework/data/r2dbc/repository/query/R2dbcQueryCreator.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/query/R2dbcQueryCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,21 +18,18 @@ package org.springframework.data.r2dbc.repository.query;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.r2dbc.core.ReactiveDataAccessStrategy;
 import org.springframework.data.r2dbc.core.StatementMapper;
+import org.springframework.data.r2dbc.repository.Lock;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
 import org.springframework.data.relational.core.query.Criteria;
-import org.springframework.data.relational.core.sql.Column;
-import org.springframework.data.relational.core.sql.Expression;
-import org.springframework.data.relational.core.sql.Expressions;
-import org.springframework.data.relational.core.sql.Functions;
-import org.springframework.data.relational.core.sql.SqlIdentifier;
-import org.springframework.data.relational.core.sql.Table;
+import org.springframework.data.relational.core.sql.*;
 import org.springframework.data.relational.repository.query.RelationalEntityMetadata;
 import org.springframework.data.relational.repository.query.RelationalParameterAccessor;
 import org.springframework.data.relational.repository.query.RelationalQueryCreator;
@@ -48,6 +45,7 @@ import org.springframework.r2dbc.core.PreparedOperation;
  * @author Mark Paluch
  * @author Mingyuan Wu
  * @author Myeonghyeon Lee
+ * @author Diego Krupitza
  * @since 1.1
  */
 class R2dbcQueryCreator extends RelationalQueryCreator<PreparedOperation<?>> {
@@ -58,6 +56,7 @@ class R2dbcQueryCreator extends RelationalQueryCreator<PreparedOperation<?>> {
 	private final RelationalEntityMetadata<?> entityMetadata;
 	private final List<String> projectedProperties;
 	private final Class<?> entityToRead;
+	private final Optional<Lock> lock;
 
 	/**
 	 * Creates new instance of this class with the given {@link PartTree}, {@link ReactiveDataAccessStrategy},
@@ -71,7 +70,7 @@ class R2dbcQueryCreator extends RelationalQueryCreator<PreparedOperation<?>> {
 	 */
 	public R2dbcQueryCreator(PartTree tree, ReactiveDataAccessStrategy dataAccessStrategy,
 			RelationalEntityMetadata<?> entityMetadata, RelationalParameterAccessor accessor,
-			List<String> projectedProperties) {
+			List<String> projectedProperties, Optional<Lock> lock) {
 		super(tree, accessor);
 
 		this.tree = tree;
@@ -81,6 +80,7 @@ class R2dbcQueryCreator extends RelationalQueryCreator<PreparedOperation<?>> {
 		this.entityMetadata = entityMetadata;
 		this.projectedProperties = projectedProperties;
 		this.entityToRead = entityMetadata.getTableEntity().getType();
+		this.lock = lock;
 	}
 
 	/**
@@ -138,6 +138,10 @@ class R2dbcQueryCreator extends RelationalQueryCreator<PreparedOperation<?>> {
 			selectSpec = selectSpec.distinct();
 		}
 
+		if (this.lock.isPresent()) {
+			selectSpec = selectSpec.lock(this.lock.get().value());
+		}
+
 		return statementMapper.getMappedObject(selectSpec);
 	}
 
@@ -154,15 +158,15 @@ class R2dbcQueryCreator extends RelationalQueryCreator<PreparedOperation<?>> {
 			for (String projectedProperty : projectedProperties) {
 
 				RelationalPersistentProperty property = entity.getPersistentProperty(projectedProperty);
-				Column column = table.column(property != null ? property.getColumnName() : SqlIdentifier.unquoted(projectedProperty));
+				Column column = table
+						.column(property != null ? property.getColumnName() : SqlIdentifier.unquoted(projectedProperty));
 				expressions.add(column);
 			}
 
 		} else if (tree.isExistsProjection()) {
 
-			expressions = dataAccessStrategy.getIdentifierColumns(entityToRead).stream()
-				.map(table::column)
-				.collect(Collectors.toList());
+			expressions = dataAccessStrategy.getIdentifierColumns(entityToRead).stream().map(table::column)
+					.collect(Collectors.toList());
 		} else if (tree.isCountProjection()) {
 
 			Expression countExpression = entityMetadata.getTableEntity().hasIdProperty()
@@ -171,9 +175,8 @@ class R2dbcQueryCreator extends RelationalQueryCreator<PreparedOperation<?>> {
 
 			expressions = Collections.singletonList(Functions.count(countExpression));
 		} else {
-			expressions = dataAccessStrategy.getAllColumns(entityToRead).stream()
-				.map(table::column)
-				.collect(Collectors.toList());
+			expressions = dataAccessStrategy.getAllColumns(entityToRead).stream().map(table::column)
+					.collect(Collectors.toList());
 		}
 
 		return expressions.toArray(new Expression[0]);

--- a/src/main/java/org/springframework/data/r2dbc/repository/query/R2dbcQueryMethod.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/query/R2dbcQueryMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.projection.ProjectionFactory;
+import org.springframework.data.r2dbc.repository.Lock;
 import org.springframework.data.r2dbc.repository.Modifying;
 import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
@@ -53,6 +54,7 @@ import org.springframework.util.ClassUtils;
  *
  * @author Mark Paluch
  * @author Stephen Cohen
+ * @author Diego Krupitza
  */
 public class R2dbcQueryMethod extends QueryMethod {
 
@@ -66,6 +68,7 @@ public class R2dbcQueryMethod extends QueryMethod {
 	private final Optional<Query> query;
 	private final boolean modifying;
 	private final Lazy<Boolean> isCollectionQuery;
+	private final Optional<Lock> lock;
 
 	private @Nullable RelationalEntityMetadata<?> metadata;
 
@@ -113,11 +116,11 @@ public class R2dbcQueryMethod extends QueryMethod {
 			}
 		}
 
-		this.query = Optional.ofNullable(
-				AnnotatedElementUtils.findMergedAnnotation(method, Query.class));
+		this.query = Optional.ofNullable(AnnotatedElementUtils.findMergedAnnotation(method, Query.class));
 		this.modifying = AnnotatedElementUtils.hasAnnotation(method, Modifying.class);
 		this.isCollectionQuery = Lazy.of(() -> (!(isPageQuery() || isSliceQuery())
 				&& ReactiveWrappers.isMultiValueType(metadata.getReturnType(method).getType())) || super.isCollectionQuery());
+		this.lock = Optional.ofNullable(AnnotatedElementUtils.findMergedAnnotation(method, Lock.class));
 	}
 
 	/* (non-Javadoc)
@@ -144,6 +147,22 @@ public class R2dbcQueryMethod extends QueryMethod {
 		return modifying;
 	}
 
+	/**
+	 * @return is a {@link Lock} annotation present or not.
+	 */
+	public boolean hasLockMode() {
+		return this.lock.isPresent();
+	}
+
+	/**
+	 * Looks up the {@link Lock} annotation from the query method.
+	 *
+	 * @return the {@link Optional} wrapped {@link Lock} annotation.
+	 */
+	Optional<Lock> getLock() {
+		return this.lock;
+	}
+
 	/*
 	 * All reactive query methods are streaming queries.
 	 * (non-Javadoc)
@@ -166,8 +185,7 @@ public class R2dbcQueryMethod extends QueryMethod {
 			Class<?> returnedObjectType = getReturnedObjectType();
 			Class<?> domainClass = getDomainClass();
 
-			if (ClassUtils.isPrimitiveOrWrapper(returnedObjectType)
-					|| ReflectionUtils.isVoid(returnedObjectType)) {
+			if (ClassUtils.isPrimitiveOrWrapper(returnedObjectType) || ReflectionUtils.isVoid(returnedObjectType)) {
 
 				this.metadata = new SimpleRelationalEntityMetadata<>((Class<Object>) domainClass,
 						mappingContext.getRequiredPersistentEntity(domainClass));
@@ -214,8 +232,8 @@ public class R2dbcQueryMethod extends QueryMethod {
 	}
 
 	/**
-	 * Returns the required query string declared in a {@link Query} annotation
-	 * or throws {@link IllegalStateException} if neither the annotation found nor the attribute was specified.
+	 * Returns the required query string declared in a {@link Query} annotation or throws {@link IllegalStateException} if
+	 * neither the annotation found nor the attribute was specified.
 	 *
 	 * @return the query string.
 	 * @throws IllegalStateException in case query method has no annotated query.
@@ -235,8 +253,7 @@ public class R2dbcQueryMethod extends QueryMethod {
 	}
 
 	/**
-	 * @return {@literal true} if the {@link Method} is annotated with
-	 *         {@link Query}.
+	 * @return {@literal true} if the {@link Method} is annotated with {@link Query}.
 	 */
 	public boolean hasAnnotatedQuery() {
 		return getQueryAnnotation().isPresent();

--- a/src/test/java/org/springframework/data/r2dbc/repository/AbstractR2dbcRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/AbstractR2dbcRepositoryIntegrationTests.java
@@ -23,6 +23,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.Value;
+import org.springframework.data.relational.core.sql.LockMode;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
@@ -58,6 +59,7 @@ import org.springframework.transaction.reactive.TransactionalOperator;
  *
  * @author Mark Paluch
  * @author Manousos Mathioudakis
+ * @author Diego Krupitza
  */
 public abstract class AbstractR2dbcRepositoryIntegrationTests extends R2dbcIntegrationTestSupport {
 
@@ -380,6 +382,33 @@ public abstract class AbstractR2dbcRepositoryIntegrationTests extends R2dbcInteg
 				.verifyComplete();
 	}
 
+	@Test
+	void getAllByNameWithWriteLock() {
+
+		shouldInsertNewItems();
+
+		repository.getAllByName("SCHAUFELRADBAGGER") //
+				.as(StepVerifier::create) //
+				.consumeNextWith(actual -> {
+					assertThat(actual.getName()).isEqualTo("SCHAUFELRADBAGGER");
+				}) //
+				.verifyComplete();
+	}
+
+	@Test
+	void findByNameAndFlagWithReadLock() {
+
+		shouldInsertNewItems();
+
+		repository.findByNameAndFlag("SCHAUFELRADBAGGER", true) //
+				.as(StepVerifier::create) //
+				.consumeNextWith(actual -> {
+					assertThat(actual.getName()).isEqualTo("SCHAUFELRADBAGGER");
+					assertThat(actual.isFlag()).isTrue();
+				}) //
+				.verifyComplete();
+	}
+
 	private static Object getCount(Map<String, Object> map) {
 		return map.getOrDefault("count", map.get("COUNT"));
 	}
@@ -392,6 +421,12 @@ public abstract class AbstractR2dbcRepositoryIntegrationTests extends R2dbcInteg
 
 	@NoRepositoryBean
 	interface LegoSetRepository extends ReactiveCrudRepository<LegoSet, Integer> {
+
+		@Lock(LockMode.PESSIMISTIC_WRITE)
+		Flux<LegoSet> getAllByName(String name);
+
+		@Lock(LockMode.PESSIMISTIC_READ)
+		Flux<LegoSet> findByNameAndFlag(String name, Boolean flag);
 
 		Flux<LegoSet> findByNameContains(String name);
 

--- a/src/test/java/org/springframework/data/r2dbc/repository/query/PartTreeR2dbcQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/query/PartTreeR2dbcQueryUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
@@ -48,8 +47,10 @@ import org.springframework.data.r2dbc.core.ReactiveDataAccessStrategy;
 import org.springframework.data.r2dbc.dialect.DialectResolver;
 import org.springframework.data.r2dbc.dialect.R2dbcDialect;
 import org.springframework.data.r2dbc.mapping.R2dbcMappingContext;
+import org.springframework.data.r2dbc.repository.Lock;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.Table;
+import org.springframework.data.relational.core.sql.LockMode;
 import org.springframework.data.relational.repository.query.RelationalParametersParameterAccessor;
 import org.springframework.data.repository.Repository;
 import org.springframework.data.repository.core.support.DefaultRepositoryMetadata;
@@ -64,6 +65,7 @@ import org.springframework.r2dbc.core.binding.BindTarget;
  * @author Mark Paluch
  * @author Mingyuan Wu
  * @author Myeonghyeon Lee
+ * @author Diego Krupitza
  */
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -660,8 +662,38 @@ class PartTreeR2dbcQueryUnitTests {
 			dataAccessStrategy);
 		PreparedOperation<?> query = createQuery(queryMethod, r2dbcQuery, "John");
 
-		assertThat(query.get())
-			.isEqualTo("SELECT COUNT(users.id) FROM " + TABLE + " WHERE " + TABLE + ".first_name = $1");
+		assertThat(query.get()) //
+				.isEqualTo("SELECT COUNT(users.id) FROM " + TABLE + " WHERE " + TABLE + ".first_name = $1");
+	}
+
+	@Test // gh-1041
+	void createQueryWithPessimisticWriteLock() throws Exception {
+
+		R2dbcQueryMethod queryMethod = getQueryMethod("findAllByFirstNameAndLastName", String.class, String.class);
+		PartTreeR2dbcQuery r2dbcQuery = new PartTreeR2dbcQuery(queryMethod, operations, r2dbcConverter, dataAccessStrategy);
+
+		String firstname = "Diego";
+		String lastname = "Krupitza";
+
+		PreparedOperation<?> query = createQuery(queryMethod, r2dbcQuery, firstname, lastname);
+
+		assertThat(query.get()).isEqualTo(
+				"SELECT users.id, users.first_name, users.last_name, users.date_of_birth, users.age, users.active FROM users WHERE users.first_name = $1 AND (users.last_name = $2) FOR UPDATE OF users");
+	}
+
+	@Test // gh-1041
+	void createQueryWithPessimisticReadLock() throws Exception {
+
+		R2dbcQueryMethod queryMethod = getQueryMethod("findAllByFirstNameAndAge", String.class, Integer.class);
+		PartTreeR2dbcQuery r2dbcQuery = new PartTreeR2dbcQuery(queryMethod, operations, r2dbcConverter, dataAccessStrategy);
+
+		String firstname = "Diego";
+		Integer age = 22;
+
+		PreparedOperation<?> query = createQuery(queryMethod, r2dbcQuery, firstname, age);
+
+		assertThat(query.get()).isEqualTo(
+				"SELECT users.id, users.first_name, users.last_name, users.date_of_birth, users.age, users.active FROM users WHERE users.first_name = $1 AND (users.age = $2) FOR SHARE OF users");
 	}
 
 	private PreparedOperation<?> createQuery(R2dbcQueryMethod queryMethod, PartTreeR2dbcQuery r2dbcQuery,
@@ -686,6 +718,12 @@ class PartTreeR2dbcQueryUnitTests {
 
 	@SuppressWarnings("ALL")
 	interface UserRepository extends Repository<User, Long> {
+
+		@Lock(LockMode.PESSIMISTIC_WRITE)
+		Flux<User> findAllByFirstNameAndLastName(String firstName, String lastName);
+
+		@Lock(LockMode.PESSIMISTIC_READ)
+		Flux<User> findAllByFirstNameAndAge(String firstName, Integer age);
 
 		Flux<User> findAllByFirstName(String firstName);
 

--- a/src/test/java/org/springframework/data/r2dbc/repository/query/R2dbcQueryMethodUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/query/R2dbcQueryMethodUnitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package org.springframework.data.r2dbc.repository.query;
 import static org.assertj.core.api.Assertions.*;
 
 import kotlin.Unit;
+import org.springframework.data.r2dbc.repository.Lock;
+import org.springframework.data.relational.core.sql.LockMode;
 import reactor.core.publisher.Mono;
 
 import java.lang.annotation.Retention;
@@ -47,6 +49,7 @@ import org.springframework.data.repository.core.support.DefaultRepositoryMetadat
  *
  * @author Mark Paluch
  * @author Stephen Cohen
+ * @author Diego Krupitza
  */
 class R2dbcQueryMethodUnitTests {
 
@@ -141,6 +144,32 @@ class R2dbcQueryMethodUnitTests {
 		assertThat(method.getEntityInformation().getJavaType()).isAssignableFrom(Contact.class);
 	}
 
+	@Test // GH-1041
+	void returnsQueryMethodWithCorrectLockTypeWriteLock() throws Exception {
+
+		R2dbcQueryMethod queryMethodWithWriteLock = queryMethod(PersonRepository.class, "queryMethodWithWriteLock");
+
+		assertThat(queryMethodWithWriteLock.getLock()).isPresent();
+		assertThat(queryMethodWithWriteLock.getLock().get().value()).isEqualTo(LockMode.PESSIMISTIC_WRITE);
+	}
+
+	@Test // GH-1041
+	void returnsQueryMethodWithCorrectLockTypeReadLock() throws Exception {
+
+		R2dbcQueryMethod queryMethodWithReadLock = queryMethod(PersonRepository.class, "queryMethodWithReadLock");
+
+		assertThat(queryMethodWithReadLock.getLock()).isPresent();
+		assertThat(queryMethodWithReadLock.getLock().get().value()).isEqualTo(LockMode.PESSIMISTIC_READ);
+	}
+
+	@Test // GH-1041
+	void returnsQueryMethodWithCorrectLockTypeNoLock() throws Exception {
+
+		R2dbcQueryMethod queryMethodWithWriteLock = queryMethod(SampleRepository.class, "methodReturningAnInterface");
+
+		assertThat(queryMethodWithWriteLock.getLock()).isEmpty();
+	}
+
 	private R2dbcQueryMethod queryMethod(Class<?> repository, String name, Class<?>... parameters) throws Exception {
 
 		Method method = repository.getMethod(name, parameters);
@@ -149,6 +178,12 @@ class R2dbcQueryMethodUnitTests {
 	}
 
 	interface PersonRepository extends Repository<Contact, Long> {
+
+		@Lock(LockMode.PESSIMISTIC_WRITE)
+		Mono<Contact> queryMethodWithWriteLock();
+
+		@Lock(LockMode.PESSIMISTIC_READ)
+		Mono<Contact> queryMethodWithReadLock();
 
 		Mono<Contact> findMonoByLastname(String lastname, Pageable pageRequest);
 


### PR DESCRIPTION
Methods which use the derive query functionality now can be annotated with `@Lock` to used a given `LockMode`. Right now there are two different modes `PESSIMISTIC_READ` and `PESSIMISTIC_WRITE`. Based on the dialect the right select is generated. For example for H2 `Select ... FOR UPDATE`.

Closes spring-projects/spring-data-jdbc#1041
Related tickets #643

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
